### PR TITLE
Include question type in AI prompt context

### DIFF
--- a/src/exam_helper/prompt_catalog.py
+++ b/src/exam_helper/prompt_catalog.py
@@ -65,6 +65,7 @@ class PromptCatalog:
             "solution_md": resolved_solution_md,
             "choices_yaml": self._choices_yaml(question),
             "mc_options_guidance": question.mc_options_guidance or "",
+            "question_type": question.question_type.value,
         }
         user_template = payload["user_prompt_template"]
         user_prompt = self._safe_format(user_template, values)
@@ -92,7 +93,7 @@ class PromptCatalog:
     @staticmethod
     def _safe_format(template: str, values: dict[str, str]) -> str:
         formatter = Formatter()
-        allowed = {"title", "prompt_md", "solution_md", "choices_yaml", "mc_options_guidance"}
+        allowed = {"title", "prompt_md", "solution_md", "choices_yaml", "mc_options_guidance", "question_type"}
         for _, field_name, _, _ in formatter.parse(template):
             if field_name and field_name not in allowed:
                 raise ValueError(f"Unsupported template key: {field_name}")

--- a/src/exam_helper/prompt_templates.yaml
+++ b/src/exam_helper/prompt_templates.yaml
@@ -1,13 +1,13 @@
 actions:
   suggest_title:
     system_prompt: "You generate short, descriptive titles for physics exam problems."
-    user_prompt_template: "Generate a concise title (max 8 words) for:\n{prompt_md}"
+    user_prompt_template: "Generate a concise title (max 8 words) for:\nQuestion type: {question_type}\n{prompt_md}"
   improve_prompt:
     system_prompt: "You improve physics exam problem statements for clarity and precision."
-    user_prompt_template: "Improve this prompt while preserving intent and difficulty:\n{prompt_md}"
+    user_prompt_template: "Improve this prompt while preserving intent and difficulty.\nQuestion type: {question_type}\nPrompt:\n{prompt_md}"
   draft_solution:
     system_prompt: "You write brief but complete worked solutions for calculus-based physics exams. If an existing solution draft is provided, treat it as editable author guidance: improve wording, fix mistakes, and re-check correctness against the current prompt. Be concise: target 3-5 short lines plus one final answer line unless complexity requires more. Every mathematical expression, equation, or scientific notation must be written in LaTeX inline math mode using \\( ... \\). Do not repeat the problem statement or include any 'Problem (verbatim):' line. End with a line that starts exactly with 'Final answer: ' and provide the computed final result."
-    user_prompt_template: "Write or improve the worked solution.\nTitle: {title}\nPrompt:\n{prompt_md}\nCurrent worked solution draft (may be blank, and may include author guidance):\n{solution_md}"
+    user_prompt_template: "Write or improve the worked solution.\nQuestion type: {question_type}\nTitle: {title}\nPrompt:\n{prompt_md}\nCurrent worked solution draft (may be blank, and may include author guidance):\n{solution_md}"
   distractors:
     system_prompt: "Generate complete multiple-choice options from an existing worked solution. Return strict JSON array with exactly 5 objects (A-E). Each object must have keys: label, content_md, is_correct, rationale. Exactly one option must be correct. Do not return any additional keys or narrative text."
-    user_prompt_template: "Question prompt:\n{prompt_md}\nWorked solution (authoritative, use this to determine final answer):\n{solution_md}\nAuthor guidance for distractors:\n{mc_options_guidance}\nCurrent MC options draft (may be blank; revise or replace as needed):\n{choices_yaml}\nGenerate exactly options A, B, C, D, E."
+    user_prompt_template: "Question type: {question_type}\nQuestion prompt:\n{prompt_md}\nWorked solution (authoritative, use this to determine final answer):\n{solution_md}\nAuthor guidance for distractors:\n{mc_options_guidance}\nCurrent MC options draft (may be blank; revise or replace as needed):\n{choices_yaml}\nGenerate exactly options A, B, C, D, E."

--- a/tests/unit/test_prompt_catalog.py
+++ b/tests/unit/test_prompt_catalog.py
@@ -28,6 +28,7 @@ def test_prompt_catalog_applies_overall_and_scoped_overrides() -> None:
     )
     assert "Always keep SI units." in bundle.system_prompt
     assert "Make wording beginner-friendly." in bundle.system_prompt
+    assert "Question type: free_response" in bundle.user_prompt
 
 
 def test_figure_placeholders_show_ids_and_captions() -> None:
@@ -57,10 +58,16 @@ def test_draft_solution_prompt_includes_existing_solution_text() -> None:
             "id": "q_sol",
             "title": "Kinematics",
             "prompt_md": "Find velocity.",
+            "question_type": "multiple_choice",
+            "choices": [
+                {"label": "A", "content_md": "10 m/s", "is_correct": False},
+                {"label": "B", "content_md": "12 m/s", "is_correct": True},
+            ],
             "solution": {"worked_solution_md": "Use v = v0 + at; Final answer: 12 m/s"},
         }
     )
     bundle = catalog.compose(action="draft_solution", question=q)
+    assert "Question type: multiple_choice" in bundle.user_prompt
     assert "Current worked solution draft" in bundle.user_prompt
     assert "Final answer: 12 m/s" in bundle.user_prompt
 
@@ -80,6 +87,7 @@ def test_distractors_prompt_includes_existing_choices_yaml() -> None:
         }
     )
     bundle = catalog.compose(action="distractors", question=q, solution_md="Final answer: 2 m/s^2")
+    assert "Question type: multiple_choice" in bundle.user_prompt
     assert "Author guidance for distractors:" in bundle.user_prompt
     assert "Current MC options draft (may be blank; revise or replace as needed):" in bundle.user_prompt
     assert "Avoid using the previous correct answer as a distractor." in bundle.user_prompt


### PR DESCRIPTION
## Summary
- include existing QuestionType value in prompt composition as question_type
- add question_type to allowed template fields for safe formatting
- update all AI user prompt templates to explicitly include question type
- expand prompt catalog unit tests to cover question-type prompt context

## Testing
- uv run --extra dev pytest -q tests/unit/test_prompt_catalog.py
- uv run --extra dev pytest -q

fix #9