### PR TITLE
Issue #25: add soft-delete button for questions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,8 @@ Core requirements:
 ### Standard Issue Development Flow
 
 1. Check out `main` and update it before starting issue work.
+   - Always perform this update on `main` before any issue-branch pull/sync work.
+   - If sandbox/network restrictions block the update command, request an elevated command and retry.
 2. Create a dedicated branch for the issue (for example, `issue-123-short-name`) **before making any code or docs edits**.
 3. Implement and test changes on that branch (never do issue implementation work directly on `main`).
 4. Open a **draft PR** from the branch into `main` as soon as implementation starts.

--- a/src/exam_helper/app.py
+++ b/src/exam_helper/app.py
@@ -298,6 +298,13 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
             },
         )
 
+    @app.post("/questions/{question_id}/delete")
+    def delete_question(question_id: str) -> RedirectResponse:
+        question = repo.get_question(question_id)
+        question.is_deleted = True
+        repo.save_question(question)
+        return RedirectResponse("/", status_code=303)
+
     @app.post("/questions/save")
     def save_question(
         question_id: str = Form(...),
@@ -328,6 +335,7 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
                 "id": question_id,
                 "title": title,
                 "points": points,
+                "is_deleted": (existing.is_deleted if existing else False),
                 "question_type": QuestionType(question_type),
                 "choices": choices,
                 "solution": {
@@ -381,6 +389,7 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
                     },
                     "figures": figures,
                     "points": payload.points,
+                    "is_deleted": (existing.is_deleted if existing else False),
                 }
             )
             _mark_typed_solution_stale_if_needed(existing, question)

--- a/src/exam_helper/models.py
+++ b/src/exam_helper/models.py
@@ -71,6 +71,7 @@ class Question(BaseModel):
     tags: list[str] = Field(default_factory=list)
     difficulty: int = 3
     points: int = 5
+    is_deleted: bool = False
     question_type: QuestionType = QuestionType.free_response
     mc_options_guidance: str = ""
     figures: list[FigureData] = Field(default_factory=list)

--- a/src/exam_helper/templates/index.html
+++ b/src/exam_helper/templates/index.html
@@ -30,6 +30,16 @@
       details { margin: 0.6rem 0; }
       .settings-wrap { margin-top: 1.8rem; }
       .settings-status { font-size: 0.85rem; color: #666; margin-left: 0.6rem; }
+      .actions { display: flex; gap: 0.75rem; align-items: center; }
+      .btn-link-danger {
+        border: 0;
+        background: none;
+        color: #b00020;
+        text-decoration: underline;
+        cursor: pointer;
+        padding: 0;
+        font: inherit;
+      }
     </style>
   </head>
   <body>
@@ -78,7 +88,14 @@
             {% endif %}
           </td>
           <td>{{ q.question_type.value }}</td>
-          <td><a href="/questions/{{ q.id }}/edit">Edit</a></td>
+          <td>
+            <div class="actions">
+              <a href="/questions/{{ q.id }}/edit">Edit</a>
+              <form method="post" action="/questions/{{ q.id }}/delete" onsubmit="return confirm('Delete question {{ q.id }} from listings? The YAML file will remain on disk.');">
+                <button class="btn-link-danger" type="submit">Delete</button>
+              </form>
+            </div>
+          </td>
         </tr>
         {% endfor %}
       </tbody>

--- a/tests/unit/test_models_repository.py
+++ b/tests/unit/test_models_repository.py
@@ -78,3 +78,16 @@ def test_init_project_accepts_custom_model(tmp_path: Path) -> None:
     repo.init_project("Exam", "Physics", openai_model="gpt-5.2-custom")
     data = yaml.safe_load((tmp_path / "project.yaml").read_text(encoding="utf-8"))
     assert data["ai"]["model"] == "gpt-5.2-custom"
+
+
+def test_list_questions_excludes_soft_deleted_by_default(tmp_path: Path) -> None:
+    repo = ProjectRepository(tmp_path)
+    repo.init_project("Exam", "Physics")
+    repo.save_question(Question(id="q_active", title="Active"))
+    repo.save_question(Question(id="q_deleted", title="Deleted", is_deleted=True))
+
+    active_only = repo.list_questions()
+    assert [q.id for q in active_only] == ["q_active"]
+
+    all_questions = repo.list_questions(include_deleted=True)
+    assert [q.id for q in all_questions] == ["q_active", "q_deleted"]

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -49,3 +49,23 @@ def test_validate_project_ignores_legacy_checker_data(tmp_path: Path) -> None:
         encoding="utf-8",
     )
     assert validate_project(repo) == []
+
+
+def test_validate_project_skips_soft_deleted_questions(tmp_path: Path) -> None:
+    repo = ProjectRepository(tmp_path)
+    repo.init_project("Exam", "Physics")
+    repo.save_question(
+        Question(
+            id="q_deleted",
+            title="t",
+            is_deleted=True,
+            solution={
+                "answer_python_code": (
+                    "def solve(params, context):\n"
+                    "    raise RuntimeError('boom')\n"
+                ),
+                "parameters": {},
+            },
+        )
+    )
+    assert validate_project(repo) == []


### PR DESCRIPTION
## Summary
- add a Delete action on the home question list
- implement soft-delete by setting is_deleted: true in question YAML instead of removing files
- hide soft-deleted questions from list, validation, and DOCX export by default
- preserve deleted state on save/autosave so deleted questions stay hidden
- add tests for repository filtering, app delete flow, validation skip, and export skip
- update AGENTS workflow note to always update main before issue sync/pull work (with elevation when needed)

## Testing
- uv run --extra dev pytest -q

fix #25