### PR TITLE
Improve generated concept-title guidance

### DIFF
--- a/src/exam_helper/prompt_templates.yaml
+++ b/src/exam_helper/prompt_templates.yaml
@@ -10,6 +10,9 @@ actions:
       Extract variable values into Template Parameters (YAML-compatible key/value mapping).
       Use {{parameter_name}} references in question_template_md.
       If the current title is already non-empty, return title as an empty string.
+      If the current title is empty, generate a short title that hints at the concept (under 10 words; shorter is better).
+      If a named law or theorem is central to the problem, start the title with "<Law or Theorem Name>: ...".
+      The title should not restate the full problem statement.
       Do not include any prose before or after the JSON object.
     user_prompt_template: |
       Rewrite this question and extract parameters.

--- a/tests/unit/test_prompt_catalog.py
+++ b/tests/unit/test_prompt_catalog.py
@@ -11,6 +11,9 @@ def test_prompt_catalog_builds_rewrite_prompt() -> None:
     q.solution.parameters = {"v": 12}
     bundle = catalog.compose(action="rewrite_parameterize", question=q)
     assert "strict JSON object" in bundle.system_prompt
+    assert "under 10 words" in bundle.system_prompt
+    assert "<Law or Theorem Name>: ..." in bundle.system_prompt
+    assert "should not restate the full problem statement" in bundle.system_prompt
     assert "Rendered Question (Markdown):" in bundle.user_prompt
     assert "Template Parameters (YAML):" in bundle.user_prompt
     assert "```markdown" in bundle.user_prompt


### PR DESCRIPTION
﻿fix #36

## Summary
- tighten rewrite-title guidance so generated titles are short concept hints (under 10 words)
- require named law/theorem prefix when central to the problem (for example, "Ideal Gas Law: ...")
- keep existing behavior to return empty title when the question already has one
- add prompt-catalog unit assertions for the new title-guidance instructions
