### PR TITLE
Make serve accept positional project path

### DIFF
--- a/src/exam_helper/cli.py
+++ b/src/exam_helper/cli.py
@@ -64,7 +64,7 @@ def cmd_serve(args: argparse.Namespace) -> int:
         print("OpenAI key loaded.")
     else:
         print("OpenAI key not configured. AI features will be unavailable.")
-    app = create_app(project_root=Path(args.project), openai_key=key)
+    app = create_app(project_root=Path(args.path), openai_key=key)
     uvicorn.run(
         app,
         host=args.host,
@@ -86,9 +86,9 @@ def build_parser() -> argparse.ArgumentParser:
     p_init.set_defaults(func=cmd_init)
 
     p_serve = sub.add_parser("serve", help="Serve the local web app.")
+    p_serve.add_argument("path", nargs="?", default=".")
     p_serve.add_argument("--host", default="127.0.0.1")
     p_serve.add_argument("--port", type=int, default=8000)
-    p_serve.add_argument("--project", default=".")
     p_serve.add_argument("--openai-key", default=None)
     p_serve.add_argument("-v", "--verbose", action="count", default=0)
     p_serve.set_defaults(func=cmd_serve)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,0 +1,50 @@
+﻿from __future__ import annotations
+
+from pathlib import Path
+
+from exam_helper import cli
+
+
+def test_serve_parser_accepts_positional_path() -> None:
+    parser = cli.build_parser()
+
+    args = parser.parse_args(["serve", "my-project"])
+
+    assert args.path == "my-project"
+
+
+def test_serve_parser_defaults_path_to_current_directory() -> None:
+    parser = cli.build_parser()
+
+    args = parser.parse_args(["serve"])
+
+    assert args.path == "."
+
+
+def test_cmd_serve_uses_path_for_project_root(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_create_app(*, project_root: Path, openai_key: str | None):
+        captured["project_root"] = project_root
+        captured["openai_key"] = openai_key
+        return object()
+
+    def fake_run(app, host: str, port: int, log_level: str) -> None:
+        captured["app"] = app
+        captured["host"] = host
+        captured["port"] = port
+        captured["log_level"] = log_level
+
+    monkeypatch.setattr(cli, "create_app", fake_create_app)
+    monkeypatch.setattr(cli.uvicorn, "run", fake_run)
+    monkeypatch.setattr(cli, "resolve_openai_api_key", lambda _: "key")
+
+    parser = cli.build_parser()
+    args = parser.parse_args(["serve", "my-project", "--port", "9000"])
+
+    assert cli.cmd_serve(args) == 0
+    assert captured["project_root"] == Path("my-project")
+    assert captured["openai_key"] == "key"
+    assert captured["host"] == "127.0.0.1"
+    assert captured["port"] == 9000
+    assert captured["log_level"] == "info"


### PR DESCRIPTION
- align serve with init by using the same positional path argument\n- remove the --project flag from CLI parsing\n- add unit tests for parser behavior and cmd_serve project root wiring\n\nFixes #24