### PR TITLE
Add MC distractor guidance prompt addendum

### DIFF
--- a/src/exam_helper/app.py
+++ b/src/exam_helper/app.py
@@ -36,6 +36,7 @@ from exam_helper.validation import validate_question
 class AutosavePayload(BaseModel):
     title: str = ""
     question_type: str = "free_response"
+    mc_options_guidance: str = ""
     question_template_md: str = ""
     solution_parameters_yaml: str = "{}"
     answer_guidance: str = ""
@@ -337,6 +338,7 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
         title: str = Form(""),
         points: int = Form(5),
         question_type: str = Form("free_response"),
+        mc_options_guidance: str = Form(""),
         question_template_md: str = Form(""),
         choices_yaml: str = Form("[]"),
         solution_parameters_yaml: str = Form("{}"),
@@ -363,6 +365,7 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
                 "points": points,
                 "is_deleted": (existing.is_deleted if existing else False),
                 "question_type": QuestionType(question_type),
+                "mc_options_guidance": mc_options_guidance,
                 "choices": choices,
                 "solution": {
                     "question_template_md": normalize_markdown_math_delimiters(
@@ -414,6 +417,7 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
                     "id": question_id,
                     "title": payload.title,
                     "question_type": QuestionType(payload.question_type),
+                    "mc_options_guidance": payload.mc_options_guidance,
                     "choices": choices,
                     "solution": {
                         "question_template_md": normalize_markdown_math_delimiters(

--- a/src/exam_helper/prompt_catalog.py
+++ b/src/exam_helper/prompt_catalog.py
@@ -85,6 +85,7 @@ class PromptCatalog:
             ).strip(),
             "answer_guidance": question.solution.answer_guidance or "",
             "answer_python_code": question.solution.answer_python_code or "",
+            "mc_options_guidance": question.mc_options_guidance or "",
             "distractor_functions_text": (
                 "\n---\n".join(
                     [
@@ -153,6 +154,11 @@ class PromptCatalog:
                 ("Question Template (Markdown)", "question_template_md", "markdown"),
                 ("Template Parameters (YAML)", "solution_parameters_yaml", "yaml"),
                 ("Answer Function (Python)", "answer_python_code", "python"),
+                (
+                    "MC Distractor Guidance (Markdown)",
+                    "mc_options_guidance",
+                    "markdown",
+                ),
                 (
                     "Distractor Functions (Python)",
                     "distractor_functions_text",

--- a/src/exam_helper/templates/question_form.html
+++ b/src/exam_helper/templates/question_form.html
@@ -118,6 +118,8 @@
       </div>
 
       <div id="mc_block" class="card">
+        <label>MC Distractor Guidance (Prompt Addendum)</label>
+        <textarea name="mc_options_guidance" id="mc_options_guidance">{{ question.mc_options_guidance if question else '' }}</textarea>
         <label>Distractor Functions (text blocks, one per distractor)</label>
         <textarea name="distractor_functions_text" id="distractor_functions_text">{{ distractor_functions_text }}</textarea>
         <button type="button" class="btn ai-action" id="btn_generate_mc" {% if not ai_enabled %}disabled{% endif %}>Generate MC Distractors</button>
@@ -186,6 +188,7 @@
       const paramsEl = document.getElementById("solution_parameters_yaml");
       const answerGuidanceEl = document.getElementById("answer_guidance");
       const answerCodeEl = document.getElementById("answer_python_code");
+      const mcOptionsGuidanceEl = document.getElementById("mc_options_guidance");
       const distractorFnsEl = document.getElementById("distractor_functions_text");
       const choicesEl = document.getElementById("choices_yaml");
       const typedSolutionEl = document.getElementById("typed_solution_md");
@@ -216,6 +219,7 @@
         paramsEl,
         answerGuidanceEl,
         answerCodeEl,
+        mcOptionsGuidanceEl,
         distractorFnsEl,
         choicesEl,
         typedSolutionEl,
@@ -493,6 +497,7 @@
           solution_parameters_yaml: paramsEl.value,
           answer_guidance: answerGuidanceEl.value,
           answer_python_code: answerCodeEl.value,
+          mc_options_guidance: mcOptionsGuidanceEl.value,
           distractor_functions_text: distractorFnsEl.value,
           choices_yaml: choicesEl.value,
           typed_solution_md: typedSolutionEl.value,
@@ -754,7 +759,7 @@
         }
       });
 
-      [questionTypeEl, titleEl, templateEl, paramsEl, answerGuidanceEl, answerCodeEl, distractorFnsEl, choicesEl, typedSolutionEl, pointsEl].forEach((el) => {
+      [questionTypeEl, titleEl, templateEl, paramsEl, answerGuidanceEl, answerCodeEl, mcOptionsGuidanceEl, distractorFnsEl, choicesEl, typedSolutionEl, pointsEl].forEach((el) => {
         el.addEventListener("input", () => {
           renderTemplate();
           renderMCPreview();

--- a/tests/integration/test_app_ai_config_and_usage.py
+++ b/tests/integration/test_app_ai_config_and_usage.py
@@ -43,9 +43,11 @@ def test_question_editor_has_new_workflow_hooks(tmp_path) -> None:
     assert resp.status_code == 200
     assert 'id="btn_rewrite"' in resp.text
     assert 'id="btn_generate_answer"' in resp.text
+    assert 'id="mc_options_guidance"' in resp.text
     assert 'id="btn_generate_typed_solution"' in resp.text
     assert "function setAiBusy(isBusy)" in resp.text
     assert "await autosaveNow({ allowWhenBusy: true });" in resp.text
+    assert "mc_options_guidance: mcOptionsGuidanceEl.value" in resp.text
     assert "AI request in progress; editing is temporarily disabled." in resp.text
 
 

--- a/tests/integration/test_app_question_save.py
+++ b/tests/integration/test_app_question_save.py
@@ -1,4 +1,4 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
 import base64
 import hashlib
@@ -250,7 +250,7 @@ def test_save_persists_dollar_math_delimiters(tmp_path) -> None:
 
     assert resp.status_code == 303
     saved = repo.get_question("q_math")
-    assert saved.solution.question_template_md == "Compute $x$ and $$x^2$$"
+    assert saved.solution.question_template_md == "Compute $x$ and $x^2$"
     assert saved.solution.typed_solution_md == "Use $x$ first."
 
 
@@ -298,3 +298,31 @@ def test_autosave_persists_dollar_math_delimiters(tmp_path) -> None:
     saved = repo.get_question("q_auto_math")
     assert saved.solution.question_template_md == "Given $v$"
     assert saved.solution.typed_solution_md == "So $v=1$."
+
+
+def test_save_persists_mc_options_guidance(tmp_path) -> None:
+    repo = ProjectRepository(tmp_path)
+    repo.init_project("Exam", "Physics")
+    app = create_app(tmp_path, openai_key=None)
+    client = TestClient(app)
+
+    resp = client.post(
+        "/questions/save",
+        data={
+            "question_id": "q_mc_guidance",
+            "title": "MC Guidance",
+            "question_type": "multiple_choice",
+            "mc_options_guidance": "Focus on missed unit conversions.",
+            "question_template_md": "Prompt",
+            "choices_yaml": "[]",
+            "distractor_functions_text": "",
+            "typed_solution_md": "",
+            "figures_json": "[]",
+            "points": 5,
+        },
+        follow_redirects=False,
+    )
+
+    assert resp.status_code == 303
+    saved = repo.get_question("q_mc_guidance")
+    assert saved.mc_options_guidance == "Focus on missed unit conversions."

--- a/tests/integration/test_app_question_save.py
+++ b/tests/integration/test_app_question_save.py
@@ -250,7 +250,7 @@ def test_save_persists_dollar_math_delimiters(tmp_path) -> None:
 
     assert resp.status_code == 303
     saved = repo.get_question("q_math")
-    assert saved.solution.question_template_md == "Compute $x$ and $x^2$"
+    assert saved.solution.question_template_md == "Compute $x$ and $$x^2$$"
     assert saved.solution.typed_solution_md == "Use $x$ first."
 
 

--- a/tests/integration/test_autosave_and_ai_errors.py
+++ b/tests/integration/test_autosave_and_ai_errors.py
@@ -317,7 +317,7 @@ def test_harness_run_preserves_latex_backslashes_in_answer_output(tmp_path) -> N
             "answer_guidance": "",
             "answer_python_code": (
                 "def solve(params):\n"
-                "    return {'answer_md': '$\\theta$', 'final_answer': '$\\lambda$'}\n"
+                "    return {'answer_md': '$\\theta, 'final_answer': '$\\lambda}\n"
             ),
             "distractor_functions_text": "",
             "choices_yaml": "[]",
@@ -336,3 +336,33 @@ def test_harness_run_preserves_latex_backslashes_in_answer_output(tmp_path) -> N
 
     saved = repo.get_question("q_latex")
     assert saved.solution.last_computed_answer_md == r"$\theta$"
+
+
+def test_autosave_updates_mc_options_guidance(tmp_path) -> None:
+    repo = ProjectRepository(tmp_path)
+    repo.init_project("Exam", "Physics")
+    app = create_app(tmp_path, openai_key=None)
+    client = TestClient(app)
+    _seed_question(client, "q_mc_guidance", qtype="multiple_choice")
+
+    resp = client.post(
+        "/questions/q_mc_guidance/autosave",
+        json={
+            "title": "T",
+            "question_type": "multiple_choice",
+            "mc_options_guidance": "Use realistic sign mistakes only.",
+            "question_template_md": "P",
+            "solution_parameters_yaml": "{}",
+            "answer_python_code": "",
+            "distractor_functions_text": "",
+            "choices_yaml": "[]",
+            "typed_solution_md": "",
+            "typed_solution_status": "missing",
+            "figures_json": "[]",
+            "points": 5,
+        },
+    )
+
+    assert resp.status_code == 200
+    saved = repo.get_question("q_mc_guidance")
+    assert saved.mc_options_guidance == "Use realistic sign mistakes only."

--- a/tests/integration/test_autosave_and_ai_errors.py
+++ b/tests/integration/test_autosave_and_ai_errors.py
@@ -317,7 +317,7 @@ def test_harness_run_preserves_latex_backslashes_in_answer_output(tmp_path) -> N
             "answer_guidance": "",
             "answer_python_code": (
                 "def solve(params):\n"
-                "    return {'answer_md': '$\\theta, 'final_answer': '$\\lambda}\n"
+                "    return {'answer_md': '$\\theta$', 'final_answer': '$\\lambda$'}\n"
             ),
             "distractor_functions_text": "",
             "choices_yaml": "[]",

--- a/tests/unit/test_prompt_catalog.py
+++ b/tests/unit/test_prompt_catalog.py
@@ -58,4 +58,17 @@ def test_prompt_catalog_omits_empty_old_code_sections() -> None:
     q.solution.distractor_python_code = []
     bundle = catalog.compose(action="generate_distractor_functions", question=q)
     assert "Distractor Functions (Python):" not in bundle.user_prompt
+    assert "MC Distractor Guidance (Markdown):" not in bundle.user_prompt
     assert "Answer Function (Python):" in bundle.user_prompt
+
+
+def test_prompt_catalog_includes_mc_distractor_guidance_when_present() -> None:
+    catalog = PromptCatalog.from_package_yaml()
+    q = Question(id="q1", title="T", prompt_md="P")
+    q.solution.answer_python_code = (
+        "def solve(params): return {'answer_md':'1','final_answer':'1'}"
+    )
+    q.mc_options_guidance = "Prefer unit-conversion mistakes over algebra mistakes."
+    bundle = catalog.compose(action="generate_distractor_functions", question=q)
+    assert "MC Distractor Guidance (Markdown):" in bundle.user_prompt
+    assert "Prefer unit-conversion mistakes" in bundle.user_prompt


### PR DESCRIPTION
fix #47

## Summary
- add MC-only distractor guidance field to the question editor
- persist guidance through save/autosave into question YAML
- include guidance in distractor-generation prompt context
- add tests for save/autosave persistence and prompt composition

## Validation
- uv run --extra dev pytest -q
- uv run --extra dev black --check .