### PR TITLE
[codex] implement answer formula cleanup

### DIFF
--- a/src/exam_helper/ai_service.py
+++ b/src/exam_helper/ai_service.py
@@ -41,7 +41,7 @@ class AIService:
 
     @dataclass
     class AnswerFunctionResult:
-        answer_python_code: str
+        answer_formula_md: str
         usage: AIUsageTotals
 
     @dataclass
@@ -459,11 +459,11 @@ class AIService:
             )
         result = self._text_with_question_context(bundle, question)
         payload = self._parse_json_object(result.text)
-        answer_python_code = str(payload.get("answer_python_code", "")).strip()
-        if not answer_python_code:
-            raise ValueError("AI response field 'answer_python_code' is required.")
+        answer_formula_md = str(payload.get("answer_formula_md", "")).strip()
+        if not answer_formula_md:
+            raise ValueError("AI response field 'answer_formula_md' is required.")
         return AIService.AnswerFunctionResult(
-            answer_python_code=answer_python_code,
+            answer_formula_md=answer_formula_md,
             usage=result.usage,
         )
 

--- a/src/exam_helper/ai_service.py
+++ b/src/exam_helper/ai_service.py
@@ -40,7 +40,7 @@ class AIService:
         usage: AIUsageTotals
 
     @dataclass
-    class AnswerFunctionResult:
+    class AnswerFormulaResult:
         answer_formula_md: str
         usage: AIUsageTotals
 
@@ -444,13 +444,13 @@ class AIService:
             usage=result.usage,
         )
 
-    def generate_answer_function(
+    def generate_answer_formula(
         self,
         question: Question,
         error_feedback: str = "",
-    ) -> AnswerFunctionResult:
+    ) -> AnswerFormulaResult:
         bundle = self.compose_prompt(
-            action="generate_answer_function", question=question
+            action="generate_answer_formula", question=question
         )
         if error_feedback.strip():
             bundle = PromptBundle(
@@ -462,7 +462,7 @@ class AIService:
         answer_formula_md = str(payload.get("answer_formula_md", "")).strip()
         if not answer_formula_md:
             raise ValueError("AI response field 'answer_formula_md' is required.")
-        return AIService.AnswerFunctionResult(
+        return AIService.AnswerFormulaResult(
             answer_formula_md=answer_formula_md,
             usage=result.usage,
         )

--- a/src/exam_helper/app.py
+++ b/src/exam_helper/app.py
@@ -314,9 +314,6 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
                 content_md = normalize_markdown_math_delimiters(
                     str(preview.get("content_md", ""))
                 )
-                rationale_md = normalize_markdown_math_delimiters(
-                    str(preview.get("rationale", spec.rationale_md or ""))
-                )
                 rows.append(
                     {
                         "label": f"Distractor {idx}",

--- a/src/exam_helper/app.py
+++ b/src/exam_helper/app.py
@@ -280,6 +280,7 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
                 "preview_answers": "",
                 "preview_rationale": "",
                 "warning": "",
+                "preview_choices": [],
             }
         try:
             result = run_mc_formula_harness(
@@ -294,8 +295,20 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
             rows: list[dict[str, Any]] = []
             preview_answers_lines: list[str] = []
             preview_rationale_lines: list[str] = []
-            if result.correct_answer_md.strip():
-                preview_answers_lines.append(f"Correct: {result.correct_answer_md}")
+            preview_choices = [
+                choice.model_dump(mode="json") for choice in result.choices
+            ]
+            for choice in result.choices:
+                label = str(choice.label or "?")
+                content = normalize_markdown_math_delimiters(choice.content_md or "")
+                preview_answers_lines.append(f"{label}. {content}")
+                rationale = normalize_markdown_math_delimiters(choice.rationale or "")
+                if rationale.strip():
+                    preview_rationale_lines.append(
+                        f"{label}. {content} - {rationale}".strip()
+                    )
+                else:
+                    preview_rationale_lines.append(f"{label}. {content}")
             for idx, spec in enumerate(mc_answer_specs, start=1):
                 preview = rows_by_source.get(f"choice_{idx}", {})
                 content_md = normalize_markdown_math_delimiters(
@@ -313,13 +326,6 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
                         "warning": str(preview.get("warning", "")),
                     }
                 )
-                if content_md.strip():
-                    preview_answers_lines.append(f"{idx}. {content_md}")
-                if content_md.strip() or rationale_md.strip():
-                    rationale_text = content_md
-                    if rationale_md.strip():
-                        rationale_text = f"{content_md} - {rationale_md}"
-                    preview_rationale_lines.append(f"{idx}. {rationale_text}".strip())
             warning = " | ".join(
                 [item for item in [*result.warnings, *result.collisions] if item]
             ).strip()
@@ -336,6 +342,7 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
                     "\n".join(preview_rationale_lines).strip()
                 ),
                 "warning": warning,
+                "preview_choices": preview_choices,
             }
         except Exception as ex:
             return {
@@ -354,6 +361,7 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
                 "preview_answers": "",
                 "preview_rationale": "",
                 "warning": str(ex),
+                "preview_choices": [],
             }
 
     def _question_form_context(question: Question | None) -> dict[str, Any]:
@@ -384,7 +392,7 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
             "distractor_functions_text": distractor_functions_text,
             "mc_answer_specs_json": dump_mc_answer_specs_json(mc_answer_specs),
             "mc_answer_rows": mc_preview["rows"],
-            "mc_correct_answer_md": mc_preview["correct_answer_md"],
+            "mc_preview_choices": mc_preview["preview_choices"],
             "mc_preview_answers": mc_preview["preview_answers"],
             "mc_preview_rationale": mc_preview["preview_rationale"],
             "mc_preview_warning": mc_preview["warning"],
@@ -703,7 +711,7 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
                         question.solution.last_computed_answer_md
                         or preview["rendered_answer_md"]
                     ),
-                    "mc_correct_answer_md": mc_preview["correct_answer_md"],
+                    "mc_preview_choices": mc_preview["preview_choices"],
                     "mc_preview_answers": mc_preview["preview_answers"],
                     "mc_preview_rationale": mc_preview["preview_rationale"],
                     "mc_preview_warning": mc_preview["warning"],

--- a/src/exam_helper/app.py
+++ b/src/exam_helper/app.py
@@ -834,9 +834,15 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
                         params=q.solution.parameters,
                         strict=True,
                     )
+                    mc_preview = _compute_mc_preview(
+                        answer_formula_md=q.solution.answer_formula_md,
+                        mc_answer_specs=q.solution.mc_answer_specs,
+                        params=q.solution.parameters,
+                    )
                     payload["mc_correct_answer_md"] = harness.correct_answer_md
-                    payload["mc_preview_rows"] = harness.row_previews
-                    payload["mc_preview_warning"] = " | ".join(harness.warnings)
+                    payload["mc_preview_rows"] = mc_preview["rows"]
+                    payload["mc_preview_warning"] = mc_preview["warning"]
+                    payload["mc_preview_choices"] = mc_preview["preview_choices"]
                     payload["choices_yaml"] = dump_choices_yaml(harness.choices)
                     payload["collisions"] = harness.collisions
                     if harness.collisions:

--- a/src/exam_helper/app.py
+++ b/src/exam_helper/app.py
@@ -278,6 +278,7 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
         }
 
     def _compute_answer_preview(question: Question | None) -> dict[str, str]:
+        """Build the non-editable answer preview payload for the editor UI."""
         if question is None:
             return {
                 "calculated_variables_md": "",

--- a/src/exam_helper/app.py
+++ b/src/exam_helper/app.py
@@ -27,6 +27,7 @@ from exam_helper.models import (
 from exam_helper.normalization import normalize_markdown_math_delimiters
 from exam_helper.repository import ProjectRepository
 from exam_helper.solution_runtime import (
+    evaluate_answer_formula,
     render_template_from_values,
     run_answer_formula,
     run_mc_harness,
@@ -41,7 +42,6 @@ class AutosavePayload(BaseModel):
     question_template_md: str = ""
     solution_parameters_yaml: str = "{}"
     answer_formula_md: str = ""
-    answer_python_code: str = ""
     answer_guidance: str = ""
     distractor_functions_text: str = ""
     choices_yaml: str = "[]"
@@ -268,8 +268,8 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
             "calculated_variables_md": answer_preview["calculated_variables_md"],
             "answer_formula_warning": answer_preview["warning"],
             "rendered_answer_md": (
-                question.solution.typed_solution_md
-                if question and question.solution.typed_solution_md.strip()
+                question.solution.last_computed_answer_md
+                if question and question.solution.last_computed_answer_md.strip()
                 else answer_preview["rendered_answer_md"]
             ),
             "question_id_default": (
@@ -284,28 +284,31 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
                 "calculated_variables_md": "",
                 "rendered_answer_md": "",
                 "warning": "",
+                "fatal_error": "",
             }
         try:
-            result = run_answer_formula(
+            locals_ns, rendered_lines, warnings, fatal_error = evaluate_answer_formula(
                 question.solution.answer_formula_md,
                 question.solution.parameters,
-                answer_text_md=question.solution.answer_guidance,
-                strict=False,
             )
             return {
                 "calculated_variables_md": normalize_markdown_math_delimiters(
-                    result.calculated_variables_md
+                    "\n".join(rendered_lines).strip()
                 ),
                 "rendered_answer_md": normalize_markdown_math_delimiters(
-                    result.answer_md
+                    render_template_from_values(
+                        question.solution.answer_guidance, locals_ns
+                    ).strip()
                 ),
-                "warning": " | ".join(result.warnings),
+                "warning": " | ".join(warnings),
+                "fatal_error": fatal_error or "",
             }
         except Exception as ex:
             return {
                 "calculated_variables_md": "",
                 "rendered_answer_md": "",
                 "warning": str(ex),
+                "fatal_error": str(ex),
             }
 
     def _mark_typed_solution_stale_if_needed(
@@ -402,7 +405,6 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
         choices_yaml: str = Form("[]"),
         solution_parameters_yaml: str = Form("{}"),
         answer_formula_md: str = Form(""),
-        answer_python_code: str = Form(""),
         answer_guidance: str = Form(""),
         distractor_functions_text: str = Form(""),
         typed_solution_md: str = Form(""),
@@ -432,11 +434,13 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
                         question_template_md
                     ),
                     "parameters": solution_parameters,
-                    "answer_formula_md": answer_formula_md or answer_python_code,
+                    "answer_formula_md": answer_formula_md,
                     "answer_guidance": answer_guidance,
                     "distractor_python_code": distractor_funcs,
                     "typed_solution_md": normalize_markdown_math_delimiters(
                         typed_solution_md
+                        if typed_solution_md
+                        else (existing.solution.typed_solution_md if existing else "")
                     ),
                     "typed_solution_status": typed_solution_status,
                     "last_computed_answer_md": (
@@ -451,9 +455,11 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
             }
         )
         preview = _compute_answer_preview(question)
-        if preview["rendered_answer_md"]:
-            question.solution.typed_solution_md = preview["rendered_answer_md"]
-        question.solution.last_computed_answer_md = preview["rendered_answer_md"]
+        if not preview["fatal_error"]:
+            question.solution.last_computed_answer_md = (
+                preview["rendered_answer_md"]
+                or question.solution.last_computed_answer_md
+            )
         _mark_typed_solution_stale_if_needed(existing, question)
         repo.save_question(question)
         return RedirectResponse("/", status_code=303)
@@ -488,13 +494,15 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
                             payload.question_template_md
                         ),
                         "parameters": solution_parameters,
-                        "answer_formula_md": (
-                            payload.answer_formula_md or payload.answer_python_code
-                        ),
+                        "answer_formula_md": payload.answer_formula_md,
                         "answer_guidance": payload.answer_guidance,
                         "distractor_python_code": distractor_funcs,
                         "typed_solution_md": normalize_markdown_math_delimiters(
                             payload.typed_solution_md
+                            if payload.typed_solution_md
+                            else (
+                                existing.solution.typed_solution_md if existing else ""
+                            )
                         ),
                         "typed_solution_status": payload.typed_solution_status,
                         "last_computed_answer_md": (
@@ -511,9 +519,11 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
                 }
             )
             preview = _compute_answer_preview(question)
-            if preview["rendered_answer_md"]:
-                question.solution.typed_solution_md = preview["rendered_answer_md"]
-            question.solution.last_computed_answer_md = preview["rendered_answer_md"]
+            if not preview["fatal_error"]:
+                question.solution.last_computed_answer_md = (
+                    preview["rendered_answer_md"]
+                    or question.solution.last_computed_answer_md
+                )
             _mark_typed_solution_stale_if_needed(existing, question)
             repo.save_question(question)
             return JSONResponse(
@@ -521,7 +531,10 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
                     "ok": True,
                     "typed_solution_status": question.solution.typed_solution_status,
                     "calculated_variables_md": preview["calculated_variables_md"],
-                    "rendered_answer_md": preview["rendered_answer_md"],
+                    "rendered_answer_md": (
+                        question.solution.last_computed_answer_md
+                        or preview["rendered_answer_md"]
+                    ),
                     "warning": preview["warning"],
                 }
             )
@@ -588,13 +601,13 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
             )
             return JSONResponse({"ok": False, "error": str(ex)}, status_code=422)
 
-    @app.post("/questions/{question_id}/ai/generate-answer-function")
-    def ai_generate_answer_function(question_id: str) -> dict:
+    @app.post("/questions/{question_id}/ai/generate-answer-formula")
+    def ai_generate_answer_formula(question_id: str) -> dict:
         try:
             q = repo.get_question(question_id)
             error_feedback = ""
             for _ in range(3):
-                result = app.state.ai.generate_answer_function(
+                result = app.state.ai.generate_answer_formula(
                     q, error_feedback=error_feedback
                 )
                 repo.add_ai_usage(result.usage)
@@ -602,10 +615,7 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
                     run_answer_formula(
                         result.answer_formula_md, q.solution.parameters, strict=True
                     )
-                    return {
-                        "ok": True,
-                        "answer_formula_md": result.answer_formula_md,
-                    }
+                    return {"ok": True, "answer_formula_md": result.answer_formula_md}
                 except Exception as ex:
                     error_feedback = str(ex)
                     q.solution.answer_formula_md = result.answer_formula_md
@@ -755,7 +765,7 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
             q = repo.get_question(question_id)
             valid_actions = {
                 "rewrite-and-parameterize": "rewrite_parameterize",
-                "generate-answer-function": "generate_answer_function",
+                "generate-answer-formula": "generate_answer_formula",
                 "generate-mc-distractors": "generate_distractor_functions",
                 "generate-typed-solution": "generate_typed_solution",
             }

--- a/src/exam_helper/app.py
+++ b/src/exam_helper/app.py
@@ -19,6 +19,7 @@ from exam_helper.export_docx import render_project_docx_bytes
 from exam_helper.models import (
     AIUsageTotals,
     DistractorFunction,
+    MCAnswerSpec,
     MCChoice,
     ProjectConfig,
     Question,
@@ -30,6 +31,7 @@ from exam_helper.solution_runtime import (
     evaluate_answer_formula,
     render_template_from_values,
     run_answer_formula,
+    run_mc_formula_harness,
     run_mc_harness,
 )
 from exam_helper.validation import validate_question
@@ -44,6 +46,7 @@ class AutosavePayload(BaseModel):
     answer_formula_md: str = ""
     answer_guidance: str = ""
     distractor_functions_text: str = ""
+    mc_answer_specs_json: str = "[]"
     choices_yaml: str = "[]"
     typed_solution_md: str = ""
     typed_solution_status: str = "missing"
@@ -131,6 +134,19 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
         for f in funcs:
             chunks.append(f"# distractor: {f.id}\n{(f.python_code or '').strip()}")
         return "\n---\n".join(chunks).strip() + "\n"
+
+    def parse_mc_answer_specs_json(raw_json: str) -> list[MCAnswerSpec]:
+        raw = json.loads(raw_json or "[]")
+        if raw is None:
+            return []
+        if not isinstance(raw, list):
+            raise ValueError("MC answer specs must parse to a list.")
+        return [MCAnswerSpec.model_validate(item) for item in raw]
+
+    def dump_mc_answer_specs_json(specs: list[MCAnswerSpec]) -> str:
+        return json.dumps(
+            [spec.model_dump(mode="json") for spec in specs], ensure_ascii=False
+        )
 
     def parse_choices_yaml(choices_yaml: str) -> list[MCChoice]:
         def _strip_disallowed_bold(text: str) -> str:
@@ -227,6 +243,9 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
         ]
         return yaml.safe_dump(defaults, sort_keys=False)
 
+    def default_mc_answer_specs() -> list[MCAnswerSpec]:
+        return [MCAnswerSpec() for _ in range(4)]
+
     def _suggest_next_question_id() -> str:
         try:
             existing = [q.id for q in repo.list_questions(include_deleted=True)]
@@ -239,11 +258,114 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
                 return candidate
         return "q_new"
 
+    def _compute_mc_preview(
+        answer_formula_md: str,
+        mc_answer_specs: list[MCAnswerSpec],
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        if not answer_formula_md.strip():
+            return {
+                "correct_answer_md": "",
+                "choices": [],
+                "rows": [
+                    {
+                        "label": f"Distractor {idx}",
+                        "formula_md": spec.formula_md,
+                        "rationale_md": spec.rationale_md,
+                        "preview_md": "",
+                        "warning": "",
+                    }
+                    for idx, spec in enumerate(mc_answer_specs, start=1)
+                ],
+                "preview_answers": "",
+                "preview_rationale": "",
+                "warning": "",
+            }
+        try:
+            result = run_mc_formula_harness(
+                answer_formula_md=answer_formula_md,
+                mc_answer_specs=mc_answer_specs,
+                params=params,
+                strict=False,
+            )
+            rows_by_source = {
+                str(row.get("source_id", "")): row for row in result.row_previews
+            }
+            rows: list[dict[str, Any]] = []
+            preview_answers_lines: list[str] = []
+            preview_rationale_lines: list[str] = []
+            if result.correct_answer_md.strip():
+                preview_answers_lines.append(f"Correct: {result.correct_answer_md}")
+            for idx, spec in enumerate(mc_answer_specs, start=1):
+                preview = rows_by_source.get(f"choice_{idx}", {})
+                content_md = normalize_markdown_math_delimiters(
+                    str(preview.get("content_md", ""))
+                )
+                rationale_md = normalize_markdown_math_delimiters(
+                    str(preview.get("rationale", spec.rationale_md or ""))
+                )
+                rows.append(
+                    {
+                        "label": f"Distractor {idx}",
+                        "formula_md": spec.formula_md,
+                        "rationale_md": spec.rationale_md,
+                        "preview_md": content_md,
+                        "warning": str(preview.get("warning", "")),
+                    }
+                )
+                if content_md.strip():
+                    preview_answers_lines.append(f"{idx}. {content_md}")
+                if content_md.strip() or rationale_md.strip():
+                    rationale_text = content_md
+                    if rationale_md.strip():
+                        rationale_text = f"{content_md} - {rationale_md}"
+                    preview_rationale_lines.append(f"{idx}. {rationale_text}".strip())
+            warning = " | ".join(
+                [item for item in [*result.warnings, *result.collisions] if item]
+            ).strip()
+            return {
+                "correct_answer_md": normalize_markdown_math_delimiters(
+                    result.correct_answer_md
+                ),
+                "choices": result.choices,
+                "rows": rows,
+                "preview_answers": normalize_markdown_math_delimiters(
+                    "\n".join(preview_answers_lines).strip()
+                ),
+                "preview_rationale": normalize_markdown_math_delimiters(
+                    "\n".join(preview_rationale_lines).strip()
+                ),
+                "warning": warning,
+            }
+        except Exception as ex:
+            return {
+                "correct_answer_md": "",
+                "choices": [],
+                "rows": [
+                    {
+                        "label": f"Distractor {idx}",
+                        "formula_md": spec.formula_md,
+                        "rationale_md": spec.rationale_md,
+                        "preview_md": "",
+                        "warning": str(ex),
+                    }
+                    for idx, spec in enumerate(mc_answer_specs, start=1)
+                ],
+                "preview_answers": "",
+                "preview_rationale": "",
+                "warning": str(ex),
+            }
+
     def _question_form_context(question: Question | None) -> dict[str, Any]:
-        choices_yaml = (
-            dump_choices_yaml(question.choices)
-            if question and question.choices
-            else default_mc_choices_yaml()
+        mc_answer_specs = (
+            question.solution.mc_answer_specs
+            if question and question.solution.mc_answer_specs
+            else default_mc_answer_specs()
+        )
+        mc_preview = _compute_mc_preview(
+            question.solution.answer_formula_md if question else "",
+            mc_answer_specs,
+            question.solution.parameters if question else {},
         )
         figures_json = json.dumps(
             [f.model_dump(mode="json") for f in question.figures] if question else []
@@ -257,10 +379,15 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
         answer_preview = _compute_answer_preview(question)
         return {
             "question": question,
-            "choices_yaml": choices_yaml,
             "figures_json": figures_json,
             "solution_parameters_yaml": solution_parameters_yaml,
             "distractor_functions_text": distractor_functions_text,
+            "mc_answer_specs_json": dump_mc_answer_specs_json(mc_answer_specs),
+            "mc_answer_rows": mc_preview["rows"],
+            "mc_correct_answer_md": mc_preview["correct_answer_md"],
+            "mc_preview_answers": mc_preview["preview_answers"],
+            "mc_preview_rationale": mc_preview["preview_rationale"],
+            "mc_preview_warning": mc_preview["warning"],
             "answer_formula_md": (
                 question.solution.answer_formula_md if question else ""
             ),
@@ -326,6 +453,22 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
             != _normalized_code(candidate.solution.answer_formula_md)
             or _normalized_code(existing.solution.answer_guidance)
             != _normalized_code(candidate.solution.answer_guidance)
+            or [
+                _normalized_code(spec.formula_md)
+                for spec in existing.solution.mc_answer_specs
+            ]
+            != [
+                _normalized_code(spec.formula_md)
+                for spec in candidate.solution.mc_answer_specs
+            ]
+            or [
+                _normalized_code(spec.rationale_md)
+                for spec in existing.solution.mc_answer_specs
+            ]
+            != [
+                _normalized_code(spec.rationale_md)
+                for spec in candidate.solution.mc_answer_specs
+            ]
             or [
                 _normalized_code(d.python_code)
                 for d in existing.solution.distractor_python_code
@@ -402,6 +545,7 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
         question_type: str = Form("free_response"),
         mc_options_guidance: str = Form(""),
         question_template_md: str = Form(""),
+        mc_answer_specs_json: str = Form("[]"),
         choices_yaml: str = Form("[]"),
         solution_parameters_yaml: str = Form("{}"),
         answer_formula_md: str = Form(""),
@@ -416,10 +560,17 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
             existing = repo.get_question(question_id)
         except Exception:
             existing = None
-        choices = parse_choices_yaml(choices_yaml)
         figures = json.loads(figures_json or "[]")
         solution_parameters = parse_parameters_yaml(solution_parameters_yaml)
         distractor_funcs = parse_distractor_functions_text(distractor_functions_text)
+        mc_answer_specs = parse_mc_answer_specs_json(mc_answer_specs_json)
+        mc_preview = _compute_mc_preview(
+            answer_formula_md, mc_answer_specs, solution_parameters
+        )
+        if question_type == QuestionType.multiple_choice.value and mc_answer_specs:
+            choices = mc_preview["choices"]
+        else:
+            choices = parse_choices_yaml(choices_yaml)
         question = Question.model_validate(
             {
                 "id": question_id,
@@ -436,6 +587,7 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
                     "parameters": solution_parameters,
                     "answer_formula_md": answer_formula_md,
                     "answer_guidance": answer_guidance,
+                    "mc_answer_specs": mc_answer_specs,
                     "distractor_python_code": distractor_funcs,
                     "typed_solution_md": normalize_markdown_math_delimiters(
                         typed_solution_md
@@ -455,6 +607,11 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
             }
         )
         preview = _compute_answer_preview(question)
+        mc_preview = _compute_mc_preview(
+            question.solution.answer_formula_md,
+            question.solution.mc_answer_specs,
+            question.solution.parameters,
+        )
         if not preview["fatal_error"]:
             question.solution.last_computed_answer_md = (
                 preview["rendered_answer_md"]
@@ -474,7 +631,6 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
                 existing = repo.get_question(question_id)
             except Exception:
                 existing = None
-            choices = parse_choices_yaml(payload.choices_yaml)
             figures = json.loads(payload.figures_json or "[]")
             solution_parameters = parse_parameters_yaml(
                 payload.solution_parameters_yaml
@@ -482,6 +638,17 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
             distractor_funcs = parse_distractor_functions_text(
                 payload.distractor_functions_text
             )
+            mc_answer_specs = parse_mc_answer_specs_json(payload.mc_answer_specs_json)
+            mc_preview = _compute_mc_preview(
+                payload.answer_formula_md, mc_answer_specs, solution_parameters
+            )
+            if (
+                payload.question_type == QuestionType.multiple_choice.value
+                and mc_answer_specs
+            ):
+                choices = mc_preview["choices"]
+            else:
+                choices = parse_choices_yaml(payload.choices_yaml)
             question = Question.model_validate(
                 {
                     "id": question_id,
@@ -496,6 +663,7 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
                         "parameters": solution_parameters,
                         "answer_formula_md": payload.answer_formula_md,
                         "answer_guidance": payload.answer_guidance,
+                        "mc_answer_specs": mc_answer_specs,
                         "distractor_python_code": distractor_funcs,
                         "typed_solution_md": normalize_markdown_math_delimiters(
                             payload.typed_solution_md
@@ -535,6 +703,11 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
                         question.solution.last_computed_answer_md
                         or preview["rendered_answer_md"]
                     ),
+                    "mc_correct_answer_md": mc_preview["correct_answer_md"],
+                    "mc_preview_answers": mc_preview["preview_answers"],
+                    "mc_preview_rationale": mc_preview["preview_rationale"],
+                    "mc_preview_warning": mc_preview["warning"],
+                    "mc_preview_rows": mc_preview["rows"],
                     "warning": preview["warning"],
                 }
             )
@@ -646,20 +819,37 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
                 ),
             }
             if q.question_type == QuestionType.multiple_choice:
-                funcs = [
-                    (d.id, d.python_code) for d in q.solution.distractor_python_code
-                ]
-                harness = run_mc_harness(
-                    answer_formula_md=q.solution.answer_formula_md,
-                    distractor_python_codes=funcs,
-                    params=q.solution.parameters,
-                )
-                payload["choices_yaml"] = dump_choices_yaml(harness.choices)
-                payload["collisions"] = harness.collisions
-                if harness.collisions:
-                    payload["ok"] = False
-                    payload["error"] = "MC options are not unique."
-                    return JSONResponse(payload, status_code=422)
+                if q.solution.mc_answer_specs:
+                    harness = run_mc_formula_harness(
+                        answer_formula_md=q.solution.answer_formula_md,
+                        mc_answer_specs=q.solution.mc_answer_specs,
+                        params=q.solution.parameters,
+                        strict=True,
+                    )
+                    payload["mc_correct_answer_md"] = harness.correct_answer_md
+                    payload["mc_preview_rows"] = harness.row_previews
+                    payload["mc_preview_warning"] = " | ".join(harness.warnings)
+                    payload["choices_yaml"] = dump_choices_yaml(harness.choices)
+                    payload["collisions"] = harness.collisions
+                    if harness.collisions:
+                        payload["ok"] = False
+                        payload["error"] = "MC options are not unique."
+                        return JSONResponse(payload, status_code=422)
+                else:
+                    funcs = [
+                        (d.id, d.python_code) for d in q.solution.distractor_python_code
+                    ]
+                    harness = run_mc_harness(
+                        answer_formula_md=q.solution.answer_formula_md,
+                        distractor_python_codes=funcs,
+                        params=q.solution.parameters,
+                    )
+                    payload["choices_yaml"] = dump_choices_yaml(harness.choices)
+                    payload["collisions"] = harness.collisions
+                    if harness.collisions:
+                        payload["ok"] = False
+                        payload["error"] = "MC options are not unique."
+                        return JSONResponse(payload, status_code=422)
             q.solution.last_computed_answer_md = normalize_markdown_math_delimiters(
                 answer_result.answer_md
             )

--- a/src/exam_helper/app.py
+++ b/src/exam_helper/app.py
@@ -27,7 +27,8 @@ from exam_helper.models import (
 from exam_helper.normalization import normalize_markdown_math_delimiters
 from exam_helper.repository import ProjectRepository
 from exam_helper.solution_runtime import (
-    run_answer_function,
+    render_template_from_values,
+    run_answer_formula,
     run_mc_harness,
 )
 from exam_helper.validation import validate_question
@@ -39,8 +40,9 @@ class AutosavePayload(BaseModel):
     mc_options_guidance: str = ""
     question_template_md: str = ""
     solution_parameters_yaml: str = "{}"
-    answer_guidance: str = ""
+    answer_formula_md: str = ""
     answer_python_code: str = ""
+    answer_guidance: str = ""
     distractor_functions_text: str = ""
     choices_yaml: str = "[]"
     typed_solution_md: str = ""
@@ -225,14 +227,6 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
         ]
         return yaml.safe_dump(defaults, sort_keys=False)
 
-    def _render_template_from_parameters(template: str, params: dict[str, Any]) -> str:
-        rendered = template or ""
-        for key, value in (params or {}).items():
-            rendered = re.sub(
-                r"\{\{\s*" + re.escape(str(key)) + r"\s*\}\}", str(value), rendered
-            )
-        return rendered
-
     def _suggest_next_question_id() -> str:
         try:
             existing = [q.id for q in repo.list_questions(include_deleted=True)]
@@ -260,16 +254,58 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
         distractor_functions_text = dump_distractor_functions_text(
             question.solution.distractor_python_code if question else []
         )
+        answer_preview = _compute_answer_preview(question)
         return {
             "question": question,
             "choices_yaml": choices_yaml,
             "figures_json": figures_json,
             "solution_parameters_yaml": solution_parameters_yaml,
             "distractor_functions_text": distractor_functions_text,
+            "answer_formula_md": (
+                question.solution.answer_formula_md if question else ""
+            ),
+            "answer_guidance": question.solution.answer_guidance if question else "",
+            "calculated_variables_md": answer_preview["calculated_variables_md"],
+            "answer_formula_warning": answer_preview["warning"],
+            "rendered_answer_md": (
+                question.solution.typed_solution_md
+                if question and question.solution.typed_solution_md.strip()
+                else answer_preview["rendered_answer_md"]
+            ),
             "question_id_default": (
                 question.id if question else _suggest_next_question_id()
             ),
         }
+
+    def _compute_answer_preview(question: Question | None) -> dict[str, str]:
+        if question is None:
+            return {
+                "calculated_variables_md": "",
+                "rendered_answer_md": "",
+                "warning": "",
+            }
+        try:
+            result = run_answer_formula(
+                question.solution.answer_formula_md,
+                question.solution.parameters,
+                answer_text_md=question.solution.answer_guidance,
+                strict=False,
+            )
+            return {
+                "calculated_variables_md": normalize_markdown_math_delimiters(
+                    result.calculated_variables_md
+                ),
+                "rendered_answer_md": normalize_markdown_math_delimiters(
+                    result.answer_md
+                ),
+                "warning": " | ".join(result.warnings),
+            }
+        except Exception as ex:
+            return {
+                "calculated_variables_md": "",
+                "rendered_answer_md": "",
+                "warning": str(ex),
+            }
 
     def _mark_typed_solution_stale_if_needed(
         existing: Question | None, candidate: Question
@@ -282,8 +318,10 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
 
         if (
             existing.solution.parameters != candidate.solution.parameters
-            or _normalized_code(existing.solution.answer_python_code)
-            != _normalized_code(candidate.solution.answer_python_code)
+            or _normalized_code(existing.solution.answer_formula_md)
+            != _normalized_code(candidate.solution.answer_formula_md)
+            or _normalized_code(existing.solution.answer_guidance)
+            != _normalized_code(candidate.solution.answer_guidance)
             or [
                 _normalized_code(d.python_code)
                 for d in existing.solution.distractor_python_code
@@ -362,8 +400,9 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
         question_template_md: str = Form(""),
         choices_yaml: str = Form("[]"),
         solution_parameters_yaml: str = Form("{}"),
-        answer_guidance: str = Form(""),
+        answer_formula_md: str = Form(""),
         answer_python_code: str = Form(""),
+        answer_guidance: str = Form(""),
         distractor_functions_text: str = Form(""),
         typed_solution_md: str = Form(""),
         typed_solution_status: str = Form("missing"),
@@ -392,8 +431,8 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
                         question_template_md
                     ),
                     "parameters": solution_parameters,
+                    "answer_formula_md": answer_formula_md or answer_python_code,
                     "answer_guidance": answer_guidance,
-                    "answer_python_code": answer_python_code,
                     "distractor_python_code": distractor_funcs,
                     "typed_solution_md": normalize_markdown_math_delimiters(
                         typed_solution_md
@@ -410,6 +449,10 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
                 "figures": figures,
             }
         )
+        preview = _compute_answer_preview(question)
+        if preview["rendered_answer_md"]:
+            question.solution.typed_solution_md = preview["rendered_answer_md"]
+        question.solution.last_computed_answer_md = preview["rendered_answer_md"]
         _mark_typed_solution_stale_if_needed(existing, question)
         repo.save_question(question)
         return RedirectResponse("/", status_code=303)
@@ -444,8 +487,10 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
                             payload.question_template_md
                         ),
                         "parameters": solution_parameters,
+                        "answer_formula_md": (
+                            payload.answer_formula_md or payload.answer_python_code
+                        ),
                         "answer_guidance": payload.answer_guidance,
-                        "answer_python_code": payload.answer_python_code,
                         "distractor_python_code": distractor_funcs,
                         "typed_solution_md": normalize_markdown_math_delimiters(
                             payload.typed_solution_md
@@ -464,12 +509,19 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
                     "is_deleted": (existing.is_deleted if existing else False),
                 }
             )
+            preview = _compute_answer_preview(question)
+            if preview["rendered_answer_md"]:
+                question.solution.typed_solution_md = preview["rendered_answer_md"]
+            question.solution.last_computed_answer_md = preview["rendered_answer_md"]
             _mark_typed_solution_stale_if_needed(existing, question)
             repo.save_question(question)
             return JSONResponse(
                 {
                     "ok": True,
                     "typed_solution_status": question.solution.typed_solution_status,
+                    "calculated_variables_md": preview["calculated_variables_md"],
+                    "rendered_answer_md": preview["rendered_answer_md"],
+                    "warning": preview["warning"],
                 }
             )
         except Exception as ex:
@@ -508,7 +560,7 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
             normalized_template = normalize_markdown_math_delimiters(
                 result.question_template_md
             )
-            rendered_prompt = _render_template_from_parameters(
+            rendered_prompt = render_template_from_values(
                 normalized_template, result.parameters
             )
             title = q.title.strip() or result.title.strip()
@@ -546,18 +598,18 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
                 )
                 repo.add_ai_usage(result.usage)
                 try:
-                    run_answer_function(
-                        result.answer_python_code, q.solution.parameters
+                    run_answer_formula(
+                        result.answer_formula_md, q.solution.parameters, strict=True
                     )
                     return {
                         "ok": True,
-                        "answer_python_code": result.answer_python_code,
+                        "answer_formula_md": result.answer_formula_md,
                     }
                 except Exception as ex:
                     error_feedback = str(ex)
-                    q.solution.answer_python_code = result.answer_python_code
+                    q.solution.answer_formula_md = result.answer_formula_md
             raise ValueError(
-                "AI-generated answer function failed validation after 3 attempts. "
+                "AI-generated answer formula failed validation after 3 attempts. "
                 f"Last error: {error_feedback}"
             )
         except Exception as ex:
@@ -567,8 +619,10 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
     def run_harness(question_id: str) -> dict:
         try:
             q = repo.get_question(question_id)
-            answer_result = run_answer_function(
-                q.solution.answer_python_code, q.solution.parameters
+            answer_result = run_answer_formula(
+                q.solution.answer_formula_md,
+                q.solution.parameters,
+                answer_text_md=q.solution.answer_guidance,
             )
             payload: dict[str, Any] = {
                 "ok": True,
@@ -576,13 +630,16 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
                     answer_result.answer_md
                 ),
                 "final_answer_text": answer_result.final_answer,
+                "calculated_variables_md": normalize_markdown_math_delimiters(
+                    answer_result.calculated_variables_md
+                ),
             }
             if q.question_type == QuestionType.multiple_choice:
                 funcs = [
                     (d.id, d.python_code) for d in q.solution.distractor_python_code
                 ]
                 harness = run_mc_harness(
-                    answer_python_code=q.solution.answer_python_code,
+                    answer_formula_md=q.solution.answer_formula_md,
                     distractor_python_codes=funcs,
                     params=q.solution.parameters,
                 )
@@ -618,7 +675,7 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
                 repo.add_ai_usage(result.usage)
                 last_funcs = result.distractors
                 harness = run_mc_harness(
-                    answer_python_code=q.solution.answer_python_code,
+                    answer_formula_md=q.solution.answer_formula_md,
                     distractor_python_codes=[
                         (d.id, d.python_code) for d in result.distractors
                     ],

--- a/src/exam_helper/models.py
+++ b/src/exam_helper/models.py
@@ -37,6 +37,11 @@ class MCChoice(BaseModel):
     rationale: str | None = None
 
 
+class MCAnswerSpec(BaseModel):
+    formula_md: str = ""
+    rationale_md: str = ""
+
+
 class DistractorFunction(BaseModel):
     id: str
     python_code: str = ""
@@ -59,6 +64,7 @@ class Solution(BaseModel):
     parameters: dict[str, Any] = Field(default_factory=dict)
     answer_formula_md: str = ""
     answer_guidance: str = ""
+    mc_answer_specs: list[MCAnswerSpec] = Field(default_factory=list)
     distractor_python_code: list[DistractorFunction] = Field(default_factory=list)
     typed_solution_md: str = ""
     typed_solution_status: Literal["missing", "fresh", "stale"] = "missing"

--- a/src/exam_helper/models.py
+++ b/src/exam_helper/models.py
@@ -53,10 +53,12 @@ class DistractorFunction(BaseModel):
 
 
 class Solution(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
     question_template_md: str = ""
     parameters: dict[str, Any] = Field(default_factory=dict)
+    answer_formula_md: str = ""
     answer_guidance: str = ""
-    answer_python_code: str = ""
     distractor_python_code: list[DistractorFunction] = Field(default_factory=list)
     typed_solution_md: str = ""
     typed_solution_status: Literal["missing", "fresh", "stale"] = "missing"

--- a/src/exam_helper/prompt_catalog.py
+++ b/src/exam_helper/prompt_catalog.py
@@ -33,7 +33,7 @@ class PromptCatalog:
             raise ValueError("prompt_templates.yaml must define 'actions' mapping")
         required = {
             "rewrite_parameterize",
-            "generate_answer_function",
+            "generate_answer_formula",
             "generate_distractor_functions",
             "generate_typed_solution",
         }
@@ -140,7 +140,7 @@ class PromptCatalog:
                 ("Question Template (Markdown)", "question_template_md", "markdown"),
                 ("Template Parameters (YAML)", "solution_parameters_yaml", "yaml"),
             ],
-            "generate_answer_function": [
+            "generate_answer_formula": [
                 ("Question Type", "question_type", None),
                 ("Title", "title", None),
                 ("Question Template (Markdown)", "question_template_md", "markdown"),

--- a/src/exam_helper/prompt_catalog.py
+++ b/src/exam_helper/prompt_catalog.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from importlib.resources import files
 from string import Formatter
-import re
 
 import yaml
 
 from exam_helper.models import AIPromptConfig, Question
+from exam_helper.solution_runtime import render_template_from_values
 
 
 @dataclass(frozen=True)
@@ -71,7 +71,7 @@ class PromptCatalog:
             if action_override:
                 system_parts.append(action_override)
         system_prompt = "\n\n".join(p for p in system_parts if p)
-        rendered_question_md = self._render_template_from_parameters(
+        rendered_question_md = render_template_from_values(
             question.solution.question_template_md or "",
             question.solution.parameters or {},
         )
@@ -83,8 +83,8 @@ class PromptCatalog:
             "solution_parameters_yaml": yaml.safe_dump(
                 question.solution.parameters or {}, sort_keys=False
             ).strip(),
+            "answer_formula_md": question.solution.answer_formula_md or "",
             "answer_guidance": question.solution.answer_guidance or "",
-            "answer_python_code": question.solution.answer_python_code or "",
             "mc_options_guidance": question.mc_options_guidance or "",
             "distractor_functions_text": (
                 "\n---\n".join(
@@ -145,15 +145,15 @@ class PromptCatalog:
                 ("Title", "title", None),
                 ("Question Template (Markdown)", "question_template_md", "markdown"),
                 ("Template Parameters (YAML)", "solution_parameters_yaml", "yaml"),
-                ("Answer Guidance (Markdown)", "answer_guidance", "markdown"),
-                ("Answer Function (Python)", "answer_python_code", "python"),
+                ("Answer Formula (SymPy)", "answer_formula_md", "python"),
+                ("Answer Text (Markdown)", "answer_guidance", "markdown"),
             ],
             "generate_distractor_functions": [
                 ("Question Type", "question_type", None),
                 ("Title", "title", None),
                 ("Question Template (Markdown)", "question_template_md", "markdown"),
                 ("Template Parameters (YAML)", "solution_parameters_yaml", "yaml"),
-                ("Answer Function (Python)", "answer_python_code", "python"),
+                ("Answer Formula (SymPy)", "answer_formula_md", "python"),
                 (
                     "MC Distractor Guidance (Markdown)",
                     "mc_options_guidance",
@@ -170,7 +170,8 @@ class PromptCatalog:
                 ("Title", "title", None),
                 ("Question Template (Markdown)", "question_template_md", "markdown"),
                 ("Template Parameters (YAML)", "solution_parameters_yaml", "yaml"),
-                ("Answer Function (Python)", "answer_python_code", "python"),
+                ("Answer Formula (SymPy)", "answer_formula_md", "python"),
+                ("Answer Text (Markdown)", "answer_guidance", "markdown"),
                 ("Typed Solution (Markdown)", "typed_solution_md", "markdown"),
                 (
                     "Latest Computed Answer (Markdown)",
@@ -204,14 +205,3 @@ class PromptCatalog:
         else:
             body = text
         return f"{heading}:\n{body}"
-
-    @staticmethod
-    def _render_template_from_parameters(
-        template: str, params: dict[str, object]
-    ) -> str:
-        rendered = template or ""
-        for key, value in (params or {}).items():
-            rendered = re.sub(
-                r"\{\{\s*" + re.escape(str(key)) + r"\s*\}\}", str(value), rendered
-            )
-        return rendered

--- a/src/exam_helper/prompt_templates.yaml
+++ b/src/exam_helper/prompt_templates.yaml
@@ -19,12 +19,12 @@ actions:
       Rewrite this question and extract parameters.
 
       {context_sections}
-  generate_answer_function:
+  generate_answer_formula:
     system_prompt: |
       Return exactly one strict JSON object with one key:
       - answer_formula_md
 
-      answer_formula_md must be multiline SymPy-friendly Python expressions.
+      answer_formula_md must be multiline SymPy expressions.
       Use one expression or assignment per line.
       Expressions may use any question parameter by name.
       Intermediate variables may be defined and reused on later lines.
@@ -34,7 +34,7 @@ actions:
       If LaTeX-style backslashes are needed inside Python string literals, escape them (for example \\theta, \\(x\\)).
       Do not include any prose before or after the JSON object.
     user_prompt_template: |
-      Write or revise the deterministic Answer Formula (SymPy-friendly Python lines).
+      Write or revise the deterministic Answer Formula (SymPy expressions).
 
       {context_sections}
   generate_distractor_functions:
@@ -72,4 +72,3 @@ actions:
       Write or revise the worked Typed Solution (Markdown).
 
       {context_sections}
-

--- a/src/exam_helper/prompt_templates.yaml
+++ b/src/exam_helper/prompt_templates.yaml
@@ -22,17 +22,19 @@ actions:
   generate_answer_function:
     system_prompt: |
       Return exactly one strict JSON object with one key:
-      - answer_python_code
+      - answer_formula_md
 
-      answer_python_code must be Python code and must define:
-      - solve(params) -> dict with keys answer_md and final_answer
-
-      answer_md may include markdown and units, but must not use bold syntax.
-      final_answer must be concise answer text used for multiple-choice option generation, and must not use bold syntax.
+      answer_formula_md must be multiline SymPy-friendly Python expressions.
+      Use one expression or assignment per line.
+      Expressions may use any question parameter by name.
+      Intermediate variables may be defined and reused on later lines.
+      If the final line assigns a new variable, set answer to that same value.
+      If you create an answer variable, do not overwrite it.
+      Do not wrap the expressions in a solve() function.
       If LaTeX-style backslashes are needed inside Python string literals, escape them (for example \\theta, \\(x\\)).
       Do not include any prose before or after the JSON object.
     user_prompt_template: |
-      Write or revise the deterministic Answer Function (Python).
+      Write or revise the deterministic Answer Formula (SymPy-friendly Python lines).
 
       {context_sections}
   generate_distractor_functions:
@@ -70,5 +72,4 @@ actions:
       Write or revise the worked Typed Solution (Markdown).
 
       {context_sections}
-
 

--- a/src/exam_helper/solution_runtime.py
+++ b/src/exam_helper/solution_runtime.py
@@ -123,7 +123,7 @@ def _line_targets(node: ast.AST) -> list[str]:
     return targets
 
 
-def _evaluate_answer_formula(
+def evaluate_answer_formula(
     formula_md: str, params: dict[str, Any] | None = None
 ) -> tuple[dict[str, Any], list[str], list[str], str | None]:
     """Evaluate a multiline answer formula and capture its computed state.
@@ -246,6 +246,9 @@ def run_answer_function(
     python_code: str, params: dict[str, Any] | None = None
 ) -> AnswerRunResult:
     return run_answer_formula(python_code, params, strict=True)
+
+
+_evaluate_answer_formula = evaluate_answer_formula
 
 
 def _run_callable(

--- a/src/exam_helper/solution_runtime.py
+++ b/src/exam_helper/solution_runtime.py
@@ -37,6 +37,9 @@ class DistractorRunResult:
 class HarnessRunResult:
     choices: list[MCChoice]
     collisions: list[str]
+    row_previews: list[dict[str, Any]] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    correct_answer_md: str = ""
 
 
 def symbolic_equivalent(expr_a: str, expr_b: str) -> bool:
@@ -498,6 +501,7 @@ def run_mc_harness(
             "content_md": _strip_disallowed_bold(answer.final_answer),
             "is_correct": True,
             "rationale": "correct answer",
+            "warning": "",
         }
     ]
     for source_id, code in distractor_python_codes:
@@ -508,6 +512,7 @@ def run_mc_harness(
                 "content_md": _strip_disallowed_bold(d.distractor_md),
                 "is_correct": False,
                 "rationale": _strip_disallowed_bold(d.rationale),
+                "warning": "",
             }
         )
 
@@ -550,4 +555,177 @@ def run_mc_harness(
                 rationale=str(row["rationale"]),
             )
         )
-    return HarnessRunResult(choices=choices, collisions=collisions)
+    return HarnessRunResult(
+        choices=choices,
+        collisions=collisions,
+        row_previews=rows,
+        correct_answer_md=answer.final_answer,
+    )
+
+
+def run_mc_formula_harness(
+    answer_formula_md: str,
+    mc_answer_specs: list[Any],
+    params: dict[str, Any] | None = None,
+    *,
+    strict: bool = True,
+) -> HarnessRunResult:
+    """Evaluate formula-based MC rows and build preview choices.
+
+    The first choice is derived from the main answer formula. Remaining rows
+    are evaluated from `mc_answer_specs` in input order and are treated as
+    distractors. When `strict` is false, blank or invalid rows are skipped and
+    reported in the warnings list instead of aborting the whole preview.
+    """
+    params = params or {}
+    warnings: list[str] = []
+    row_previews: list[dict[str, Any]] = []
+
+    def _evaluate_row(
+        *, source_id: str, formula_md: str, rationale_md: str, is_correct: bool
+    ) -> MCChoice | None:
+        formula = (formula_md or "").strip()
+        if not formula:
+            message = f"{source_id}: formula is blank."
+            if strict:
+                raise SolutionRuntimeError(message)
+            warnings.append(message)
+            row_previews.append(
+                {
+                    "source_id": source_id,
+                    "content_md": "",
+                    "is_correct": is_correct,
+                    "rationale": rationale_md.strip(),
+                    "warning": message,
+                }
+            )
+            return None
+        try:
+            result = run_answer_formula(formula, params, strict=strict)
+        except SolutionRuntimeError as ex:
+            if strict:
+                raise
+            message = f"{source_id}: {ex}"
+            warnings.append(message)
+            row_previews.append(
+                {
+                    "source_id": source_id,
+                    "content_md": "",
+                    "is_correct": is_correct,
+                    "rationale": rationale_md.strip(),
+                    "warning": message,
+                }
+            )
+            return None
+        if not result.final_answer.strip():
+            message = f"{source_id}: formula did not produce an answer."
+            if strict:
+                raise SolutionRuntimeError(message)
+            warnings.append(message)
+            row_previews.append(
+                {
+                    "source_id": source_id,
+                    "content_md": "",
+                    "is_correct": is_correct,
+                    "rationale": rationale_md.strip(),
+                    "warning": message,
+                }
+            )
+            return None
+        rendered = _strip_disallowed_bold(result.final_answer)
+        row_previews.append(
+            {
+                "source_id": source_id,
+                "content_md": rendered,
+                "is_correct": is_correct,
+                "rationale": rationale_md.strip(),
+                "warning": " | ".join(result.warnings).strip(),
+            }
+        )
+        return MCChoice(
+            label="?",
+            content_md=rendered,
+            is_correct=is_correct,
+            rationale=rationale_md.strip() or ("correct answer" if is_correct else ""),
+        )
+
+    answer = _evaluate_row(
+        source_id="answer",
+        formula_md=answer_formula_md,
+        rationale_md="correct answer",
+        is_correct=True,
+    )
+    rows: list[MCChoice] = []
+    if answer is not None:
+        rows.append(answer)
+
+    for idx, spec in enumerate(mc_answer_specs, start=1):
+        formula_md = (
+            spec.get("formula_md", "")
+            if isinstance(spec, dict)
+            else getattr(spec, "formula_md", "")
+        )
+        rationale_md = (
+            spec.get("rationale_md", "")
+            if isinstance(spec, dict)
+            else getattr(spec, "rationale_md", "")
+        )
+        row = _evaluate_row(
+            source_id=f"choice_{idx}",
+            formula_md=formula_md,
+            rationale_md=rationale_md,
+            is_correct=False,
+        )
+        if row is not None:
+            rows.append(row)
+
+    seen: dict[str, str] = {}
+    collisions: list[str] = []
+    for row in row_previews:
+        content_md = str(row.get("content_md", ""))
+        if not content_md.strip():
+            continue
+        canonical = _normalize_choice_text(content_md)
+        source_id = str(row.get("source_id", ""))
+        if canonical in seen:
+            collisions.append(
+                f"Duplicate MC option between '{seen[canonical]}' and '{source_id}': {content_md}"
+            )
+        else:
+            seen[canonical] = source_id
+
+    def _sort_tuple(row: MCChoice) -> tuple[int, float, str, str]:
+        numeric = _numeric_sort_key(str(row.content_md))
+        if numeric is None:
+            return (
+                1,
+                0.0,
+                _normalize_choice_text(str(row.content_md)),
+                "answer" if row.is_correct else str(row.content_md),
+            )
+        return (
+            0,
+            numeric,
+            _normalize_choice_text(str(row.content_md)),
+            "answer" if row.is_correct else str(row.content_md),
+        )
+
+    rows.sort(key=_sort_tuple)
+    labels = ["A", "B", "C", "D", "E"]
+    choices: list[MCChoice] = []
+    for idx, row in enumerate(rows):
+        choices.append(
+            MCChoice(
+                label=labels[idx] if idx < len(labels) else "?",
+                content_md=row.content_md,
+                is_correct=row.is_correct,
+                rationale=row.rationale,
+            )
+        )
+    return HarnessRunResult(
+        choices=choices,
+        collisions=collisions,
+        row_previews=row_previews,
+        warnings=warnings,
+        correct_answer_md=answer.content_md if answer is not None else "",
+    )

--- a/src/exam_helper/solution_runtime.py
+++ b/src/exam_helper/solution_runtime.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import ast
 import math
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 import sympy as sp
@@ -20,8 +21,10 @@ class SolutionRuntimeError(RuntimeError):
 
 @dataclass
 class AnswerRunResult:
+    calculated_variables_md: str
     answer_md: str
     final_answer: str
+    warnings: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -45,6 +48,20 @@ def symbolic_equivalent(expr_a: str, expr_b: str) -> bool:
 def units_compatible(value_expr: str, expected_units: str) -> bool:
     value = ureg(value_expr)
     return value.check(expected_units)
+
+
+def render_template_from_values(template: str, values: dict[str, Any]) -> str:
+    rendered = template or ""
+    items = sorted(
+        (values or {}).items(), key=lambda item: len(str(item[0])), reverse=True
+    )
+    for key, value in items:
+        rendered = re.sub(
+            r"\{\{\s*" + re.escape(str(key)) + r"\s*\}\}",
+            str(value),
+            rendered,
+        )
+    return rendered
 
 
 def _safe_globals() -> dict[str, Any]:
@@ -74,6 +91,141 @@ def _safe_globals() -> dict[str, Any]:
     }
 
 
+def _format_value(value: Any) -> str:
+    if isinstance(value, sp.Basic):
+        return sp.sstr(value)
+    return str(value)
+
+
+def _line_targets(node: ast.AST) -> list[str]:
+    targets: list[str] = []
+
+    def visit(target: ast.AST) -> None:
+        if isinstance(target, ast.Name):
+            targets.append(target.id)
+        elif isinstance(target, (ast.Tuple, ast.List)):
+            for item in target.elts:
+                visit(item)
+
+    if isinstance(node, ast.Assign):
+        for target in node.targets:
+            visit(target)
+    elif isinstance(node, ast.AnnAssign):
+        visit(node.target)
+    elif isinstance(node, ast.AugAssign):
+        visit(node.target)
+    return targets
+
+
+def _evaluate_answer_formula(
+    formula_md: str, params: dict[str, Any] | None = None
+) -> tuple[dict[str, Any], list[str], list[str], str | None]:
+    source = normalize_python_code_string_literals(formula_md or "")
+    if not source.strip():
+        raise SolutionRuntimeError("Formula text is empty.")
+    safe_params = params or {}
+    if not isinstance(safe_params, dict):
+        raise SolutionRuntimeError("Solution params must be a mapping.")
+
+    locals_ns: dict[str, Any] = dict(safe_params)
+    locals_ns["params"] = safe_params
+    warnings: list[str] = []
+    rendered_lines: list[str] = []
+    last_value: Any = None
+    explicit_answer_defined = False
+    fatal_error: str | None = None
+    globals_ns = _safe_globals()
+
+    for lineno, raw_line in enumerate(source.splitlines(), start=1):
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+
+        try:
+            expr = ast.parse(line, mode="eval")
+        except SyntaxError:
+            try:
+                stmt = ast.parse(line, mode="exec")
+            except SyntaxError as ex:
+                fatal_error = f"Line {lineno}: {ex.msg}"
+                warnings.append(fatal_error)
+                break
+
+            node = stmt.body[0] if stmt.body else None
+            try:
+                exec(compile(stmt, "<answer_formula>", "exec"), globals_ns, locals_ns)
+            except Exception as ex:
+                fatal_error = f"Line {lineno}: {ex}"
+                warnings.append(fatal_error)
+                break
+
+            targets = _line_targets(node) if node is not None else []
+            if targets:
+                for target in targets:
+                    value = locals_ns.get(target)
+                    rendered_lines.append(f"{target} = {_format_value(value)}")
+                    last_value = value
+                    if target == "answer":
+                        if not explicit_answer_defined:
+                            warnings.append(
+                                "Formula defines answer directly; it will not be overwritten."
+                            )
+                        explicit_answer_defined = True
+            else:
+                rendered_lines.append(line)
+            continue
+
+        try:
+            value = eval(
+                compile(expr, "<answer_formula>", "eval"), globals_ns, locals_ns
+            )
+        except Exception as ex:
+            fatal_error = f"Line {lineno}: {ex}"
+            warnings.append(fatal_error)
+            break
+
+        rendered_lines.append(f"result = {_format_value(value)}")
+        last_value = value
+
+    if "answer" not in locals_ns and last_value is not None:
+        locals_ns["answer"] = last_value
+        rendered_lines.append(f"answer = {_format_value(last_value)}")
+
+    return locals_ns, rendered_lines, warnings, fatal_error
+
+
+def run_answer_formula(
+    formula_md: str,
+    params: dict[str, Any] | None = None,
+    *,
+    answer_text_md: str = "",
+    strict: bool = True,
+) -> AnswerRunResult:
+    locals_ns, rendered_lines, warnings, fatal_error = _evaluate_answer_formula(
+        formula_md, params
+    )
+    answer_value = locals_ns.get("answer")
+    if answer_value is None and strict:
+        raise SolutionRuntimeError("Formula must produce an answer value.")
+    if fatal_error and strict:
+        raise SolutionRuntimeError(fatal_error)
+    answer_md = render_template_from_values(answer_text_md, locals_ns)
+    return AnswerRunResult(
+        calculated_variables_md="\n".join(rendered_lines).strip(),
+        answer_md=answer_md.strip(),
+        final_answer=(
+            _format_value(answer_value).strip() if answer_value is not None else ""
+        ),
+        warnings=warnings,
+    )
+
+
+def run_answer_function(
+    python_code: str, params: dict[str, Any] | None = None
+) -> AnswerRunResult:
+    return run_answer_formula(python_code, params, strict=True)
+
+
 def _run_callable(
     python_code: str, fn_name: str, params: dict[str, Any]
 ) -> tuple[Any, dict[str, Any]]:
@@ -98,27 +250,6 @@ def _run_callable(
     except Exception as ex:
         raise SolutionRuntimeError(f"Solution runtime error: {ex}") from ex
     return raw, ns
-
-
-def run_answer_function(
-    python_code: str, params: dict[str, Any] | None = None
-) -> AnswerRunResult:
-    raw, _ = _run_callable(python_code, "solve", params or {})
-    if not isinstance(raw, dict):
-        raise SolutionRuntimeError("solve(params) must return a dict.")
-    answer_md = raw.get("answer_md")
-    final_answer = raw.get("final_answer")
-    if not isinstance(answer_md, str) or not answer_md.strip():
-        raise SolutionRuntimeError(
-            "solve return must include non-empty string answer_md."
-        )
-    if not isinstance(final_answer, str) or not final_answer.strip():
-        raise SolutionRuntimeError(
-            "solve return must include non-empty string final_answer."
-        )
-    return AnswerRunResult(
-        answer_md=answer_md.strip(), final_answer=final_answer.strip()
-    )
 
 
 def run_distractor_function(
@@ -199,12 +330,12 @@ def _strip_disallowed_bold(text: str) -> str:
 
 
 def run_mc_harness(
-    answer_python_code: str,
+    answer_formula_md: str,
     distractor_python_codes: list[tuple[str, str]],
     params: dict[str, Any] | None = None,
 ) -> HarnessRunResult:
     params = params or {}
-    answer = run_answer_function(answer_python_code, params)
+    answer = run_answer_formula(answer_formula_md, params, strict=True)
     rows: list[dict[str, Any]] = [
         {
             "source_id": "answer",

--- a/src/exam_helper/solution_runtime.py
+++ b/src/exam_helper/solution_runtime.py
@@ -70,6 +70,7 @@ def render_template_from_values(template: str, values: dict[str, Any]) -> str:
 
 
 def _safe_globals() -> dict[str, Any]:
+    """Return the names formulas may resolve without importing anything."""
     allowed_builtins = {
         "abs": abs,
         "min": min,
@@ -94,6 +95,51 @@ def _safe_globals() -> dict[str, Any]:
         "symbolic_equivalent": symbolic_equivalent,
         "units_compatible": units_compatible,
     }
+
+
+def _expression_name_ids(node: ast.AST) -> set[str]:
+    """Collect all loaded variable names used inside a parsed expression."""
+    return {
+        child.id
+        for child in ast.walk(node)
+        if isinstance(child, ast.Name) and isinstance(child.ctx, ast.Load)
+    }
+
+
+def _validate_formula_expression(expr: str, allowed_names: set[str]) -> None:
+    """Reject expressions that reference names outside the evaluation scope."""
+    expr_ast = ast.parse(expr, mode="eval")
+    unknown = _expression_name_ids(expr_ast) - allowed_names
+    if unknown:
+        raise SolutionRuntimeError(
+            "Unknown name(s) in formula: " + ", ".join(sorted(unknown))
+        )
+
+
+def _evaluate_formula_expression(
+    expr: str, locals_ns: dict[str, Any], globals_ns: dict[str, Any]
+) -> Any:
+    """Evaluate a single formula expression with SymPy-aware parsing."""
+    try:
+        return ast.literal_eval(expr)
+    except Exception:
+        pass
+
+    builtin_names = set()
+    builtins_obj = globals_ns.get("__builtins__")
+    if isinstance(builtins_obj, dict):
+        builtin_names = set(builtins_obj.keys())
+    allowed_names = builtin_names | {
+        name for name in {**globals_ns, **locals_ns}.keys() if not name.startswith("__")
+    }
+    _validate_formula_expression(expr, allowed_names)
+    namespace = {
+        key: value for key, value in globals_ns.items() if not key.startswith("__")
+    }
+    if isinstance(builtins_obj, dict):
+        namespace.update(builtins_obj)
+    namespace.update(locals_ns)
+    return sp.sympify(expr, locals=namespace, evaluate=True)
 
 
 def _format_value(value: Any) -> str:
@@ -144,13 +190,13 @@ def evaluate_answer_formula(
         raise SolutionRuntimeError("Solution params must be a mapping.")
 
     locals_ns: dict[str, Any] = dict(safe_params)
-    locals_ns["params"] = safe_params
     warnings: list[str] = []
     rendered_lines: list[str] = []
     last_value: Any = None
     explicit_answer_defined = False
     fatal_error: str | None = None
     globals_ns = _safe_globals()
+    steps: list[tuple[str, str | None, Any]] = []
 
     for lineno, raw_line in enumerate(source.splitlines(), start=1):
         line = raw_line.strip()
@@ -158,28 +204,70 @@ def evaluate_answer_formula(
             continue
 
         try:
-            expr = ast.parse(line, mode="eval")
-        except SyntaxError:
-            try:
-                stmt = ast.parse(line, mode="exec")
-            except SyntaxError as ex:
-                fatal_error = f"Line {lineno}: {ex.msg}"
-                warnings.append(fatal_error)
-                break
+            stmt = ast.parse(line, mode="exec")
+        except SyntaxError as ex:
+            fatal_error = f"Line {lineno}: {ex.msg}"
+            warnings.append(fatal_error)
+            break
 
-            node = stmt.body[0] if stmt.body else None
-            try:
-                exec(compile(stmt, "<answer_formula>", "exec"), globals_ns, locals_ns)
-            except Exception as ex:
-                fatal_error = f"Line {lineno}: {ex}"
-                warnings.append(fatal_error)
-                break
+        if len(stmt.body) != 1:
+            fatal_error = f"Line {lineno}: only one statement is allowed per line."
+            warnings.append(fatal_error)
+            break
 
-            targets = _line_targets(node) if node is not None else []
-            if targets:
-                for target in targets:
-                    value = locals_ns.get(target)
-                    rendered_lines.append(f"{target} = {_format_value(value)}")
+        node = stmt.body[0]
+        try:
+            if isinstance(node, ast.Expr):
+                value = _evaluate_formula_expression(
+                    ast.unparse(node.value), locals_ns, globals_ns
+                )
+                steps.append(("expr", None, value))
+                last_value = value
+                continue
+
+            if isinstance(node, ast.Assign):
+                value = _evaluate_formula_expression(
+                    ast.unparse(node.value), locals_ns, globals_ns
+                )
+                targets = _line_targets(node)
+                if not targets:
+                    steps.append(("text", None, line))
+                    continue
+                assigned_values = [value] * len(targets)
+                if len(targets) > 1 and isinstance(value, (tuple, list)):
+                    if len(value) != len(targets):
+                        raise SolutionRuntimeError(
+                            f"Line {lineno}: unpacking count does not match targets."
+                        )
+                    assigned_values = list(value)
+                for target, assigned_value in zip(targets, assigned_values):
+                    locals_ns[target] = assigned_value
+                    steps.append(("assign", target, assigned_value))
+                    last_value = assigned_value
+                    if target == "answer":
+                        if not explicit_answer_defined:
+                            warnings.append(
+                                "Formula defines answer directly; it will not be overwritten."
+                            )
+                        explicit_answer_defined = True
+                continue
+
+            if isinstance(node, ast.AnnAssign):
+                if node.value is None:
+                    raise SolutionRuntimeError(
+                        f"Line {lineno}: annotated assignments require a value."
+                    )
+                target_names = _line_targets(node)
+                if not target_names:
+                    raise SolutionRuntimeError(
+                        f"Line {lineno}: could not resolve assignment target."
+                    )
+                value = _evaluate_formula_expression(
+                    ast.unparse(node.value), locals_ns, globals_ns
+                )
+                for target in target_names:
+                    locals_ns[target] = value
+                    steps.append(("assign", target, value))
                     last_value = value
                     if target == "answer":
                         if not explicit_answer_defined:
@@ -187,25 +275,74 @@ def evaluate_answer_formula(
                                 "Formula defines answer directly; it will not be overwritten."
                             )
                         explicit_answer_defined = True
-            else:
-                rendered_lines.append(line)
-            continue
+                continue
 
-        try:
-            value = eval(
-                compile(expr, "<answer_formula>", "eval"), globals_ns, locals_ns
+            if isinstance(node, ast.AugAssign):
+                target_names = _line_targets(node)
+                if len(target_names) != 1:
+                    raise SolutionRuntimeError(
+                        f"Line {lineno}: augmented assignment must target one name."
+                    )
+                target = target_names[0]
+                if target not in locals_ns:
+                    raise SolutionRuntimeError(
+                        f"Line {lineno}: unknown name '{target}' in augmented assignment."
+                    )
+                rhs_value = _evaluate_formula_expression(
+                    ast.unparse(node.value), locals_ns, globals_ns
+                )
+                current = locals_ns[target]
+                if isinstance(node.op, ast.Add):
+                    value = current + rhs_value
+                elif isinstance(node.op, ast.Sub):
+                    value = current - rhs_value
+                elif isinstance(node.op, ast.Mult):
+                    value = current * rhs_value
+                elif isinstance(node.op, ast.Div):
+                    value = current / rhs_value
+                elif isinstance(node.op, ast.FloorDiv):
+                    value = current // rhs_value
+                elif isinstance(node.op, ast.Mod):
+                    value = current % rhs_value
+                elif isinstance(node.op, ast.Pow):
+                    value = current**rhs_value
+                else:
+                    raise SolutionRuntimeError(
+                        f"Line {lineno}: unsupported augmented assignment operator."
+                    )
+                locals_ns[target] = value
+                steps.append(("assign", target, value))
+                last_value = value
+                if target == "answer":
+                    if not explicit_answer_defined:
+                        warnings.append(
+                            "Formula defines answer directly; it will not be overwritten."
+                        )
+                    explicit_answer_defined = True
+                continue
+
+            raise SolutionRuntimeError(
+                f"Line {lineno}: unsupported statement type {type(node).__name__}."
             )
         except Exception as ex:
             fatal_error = f"Line {lineno}: {ex}"
             warnings.append(fatal_error)
             break
 
-        rendered_lines.append(f"result = {_format_value(value)}")
-        last_value = value
+    for kind, target, value in steps:
+        if kind == "expr":
+            rendered_lines.append(f"result = {_format_value(value)}")
+        elif kind == "assign" and target is not None:
+            rendered_lines.append(f"{target} = {_format_value(value)}")
+        elif kind == "text" and target is None:
+            rendered_lines.append(str(value))
 
-    if "answer" not in locals_ns and last_value is not None:
+    if fatal_error is None and "answer" not in locals_ns and last_value is not None:
         locals_ns["answer"] = last_value
-        rendered_lines.append(f"answer = {_format_value(last_value)}")
+        if steps and steps[-1][0] == "expr" and not explicit_answer_defined:
+            rendered_lines[-1] = f"answer = {_format_value(last_value)}"
+        else:
+            rendered_lines.append(f"answer = {_format_value(last_value)}")
 
     return locals_ns, rendered_lines, warnings, fatal_error
 
@@ -227,10 +364,10 @@ def run_answer_formula(
         formula_md, params
     )
     answer_value = locals_ns.get("answer")
-    if answer_value is None and strict:
-        raise SolutionRuntimeError("Formula must produce an answer value.")
     if fatal_error and strict:
         raise SolutionRuntimeError(fatal_error)
+    if answer_value is None and strict:
+        raise SolutionRuntimeError("Formula must produce an answer value.")
     answer_md = render_template_from_values(answer_text_md, locals_ns)
     return AnswerRunResult(
         calculated_variables_md="\n".join(rendered_lines).strip(),
@@ -240,12 +377,6 @@ def run_answer_formula(
         ),
         warnings=warnings,
     )
-
-
-def run_answer_function(
-    python_code: str, params: dict[str, Any] | None = None
-) -> AnswerRunResult:
-    return run_answer_formula(python_code, params, strict=True)
 
 
 _evaluate_answer_formula = evaluate_answer_formula

--- a/src/exam_helper/solution_runtime.py
+++ b/src/exam_helper/solution_runtime.py
@@ -340,10 +340,12 @@ def evaluate_answer_formula(
         elif kind == "text" and target is None:
             rendered_lines.append(str(value))
 
-    if fatal_error is None and "answer" not in locals_ns and last_value is not None:
+    if fatal_error is None and last_value is not None and not explicit_answer_defined:
         locals_ns["answer"] = last_value
-        if steps and steps[-1][0] == "expr" and not explicit_answer_defined:
+        if steps and steps[-1][0] == "expr":
             rendered_lines[-1] = f"answer = {_format_value(last_value)}"
+        elif rendered_lines:
+            rendered_lines.append(f"answer = {_format_value(last_value)}")
         else:
             rendered_lines.append(f"answer = {_format_value(last_value)}")
 

--- a/src/exam_helper/solution_runtime.py
+++ b/src/exam_helper/solution_runtime.py
@@ -51,6 +51,11 @@ def units_compatible(value_expr: str, expected_units: str) -> bool:
 
 
 def render_template_from_values(template: str, values: dict[str, Any]) -> str:
+    """Replace `{{name}}` placeholders in a template using mapping values.
+
+    Keys are applied from longest to shortest so nested placeholder names do
+    not partially overwrite each other during substitution.
+    """
     rendered = template or ""
     items = sorted(
         (values or {}).items(), key=lambda item: len(str(item[0])), reverse=True
@@ -98,6 +103,7 @@ def _format_value(value: Any) -> str:
 
 
 def _line_targets(node: ast.AST) -> list[str]:
+    """Return assignment target names declared by a single AST statement."""
     targets: list[str] = []
 
     def visit(target: ast.AST) -> None:
@@ -120,6 +126,16 @@ def _line_targets(node: ast.AST) -> list[str]:
 def _evaluate_answer_formula(
     formula_md: str, params: dict[str, Any] | None = None
 ) -> tuple[dict[str, Any], list[str], list[str], str | None]:
+    """Evaluate a multiline answer formula and capture its computed state.
+
+    The formula is treated as a sequence of plain Python lines. Each line is
+    executed or evaluated in order with the question parameters exposed as
+    locals. The return value includes:
+    - the final local namespace
+    - a human-readable log of computed variables
+    - any warnings encountered while evaluating lines
+    - the first fatal error message, if evaluation stopped early
+    """
     source = normalize_python_code_string_literals(formula_md or "")
     if not source.strip():
         raise SolutionRuntimeError("Formula text is empty.")
@@ -201,6 +217,12 @@ def run_answer_formula(
     answer_text_md: str = "",
     strict: bool = True,
 ) -> AnswerRunResult:
+    """Run an answer formula and render the final answer text.
+
+    When `strict` is true, syntax/runtime failures or a missing final `answer`
+    value raise `SolutionRuntimeError`. When false, warnings and partial output
+    are returned so the editor can preview in-progress formulas.
+    """
     locals_ns, rendered_lines, warnings, fatal_error = _evaluate_answer_formula(
         formula_md, params
     )

--- a/src/exam_helper/solution_runtime.py
+++ b/src/exam_helper/solution_runtime.py
@@ -581,6 +581,45 @@ def run_mc_formula_harness(
     warnings: list[str] = []
     row_previews: list[dict[str, Any]] = []
 
+    answer_locals, _, answer_warnings, answer_fatal_error = evaluate_answer_formula(
+        answer_formula_md, params
+    )
+    answer_value = answer_locals.get("answer")
+    if answer_fatal_error:
+        message = f"answer: {answer_fatal_error}"
+        warnings.append(message)
+        if strict:
+            raise SolutionRuntimeError(message)
+    if answer_value is None:
+        message = "answer: formula did not produce an answer."
+        warnings.append(message)
+        if strict:
+            raise SolutionRuntimeError(message)
+
+    rows: list[MCChoice] = []
+    if answer_value is not None:
+        rendered_answer = _strip_disallowed_bold(_format_value(answer_value))
+        row_previews.append(
+            {
+                "source_id": "answer",
+                "content_md": rendered_answer,
+                "is_correct": True,
+                "rationale": "correct answer",
+                "warning": " | ".join(answer_warnings).strip(),
+            }
+        )
+        rows.append(
+            MCChoice(
+                label="?",
+                content_md=rendered_answer,
+                is_correct=True,
+                rationale="correct answer",
+            )
+        )
+
+    seed_locals = dict(params)
+    seed_locals.update(answer_locals)
+
     def _evaluate_row(
         *, source_id: str, formula_md: str, rationale_md: str, is_correct: bool
     ) -> MCChoice | None:
@@ -600,12 +639,15 @@ def run_mc_formula_harness(
                 }
             )
             return None
-        try:
-            result = run_answer_formula(formula, params, strict=strict)
-        except SolutionRuntimeError as ex:
+
+        locals_ns, _, row_warnings, fatal_error = evaluate_answer_formula(
+            formula, seed_locals
+        )
+        answer_md = _format_value(locals_ns.get("answer", "")).strip()
+        if fatal_error:
+            message = f"{source_id}: {fatal_error}"
             if strict:
-                raise
-            message = f"{source_id}: {ex}"
+                raise SolutionRuntimeError(message)
             warnings.append(message)
             row_previews.append(
                 {
@@ -617,7 +659,7 @@ def run_mc_formula_harness(
                 }
             )
             return None
-        if not result.final_answer.strip():
+        if not answer_md:
             message = f"{source_id}: formula did not produce an answer."
             if strict:
                 raise SolutionRuntimeError(message)
@@ -632,14 +674,14 @@ def run_mc_formula_harness(
                 }
             )
             return None
-        rendered = _strip_disallowed_bold(result.final_answer)
+        rendered = _strip_disallowed_bold(answer_md)
         row_previews.append(
             {
                 "source_id": source_id,
                 "content_md": rendered,
                 "is_correct": is_correct,
                 "rationale": rationale_md.strip(),
-                "warning": " | ".join(result.warnings).strip(),
+                "warning": " | ".join(row_warnings).strip(),
             }
         )
         return MCChoice(
@@ -648,16 +690,6 @@ def run_mc_formula_harness(
             is_correct=is_correct,
             rationale=rationale_md.strip() or ("correct answer" if is_correct else ""),
         )
-
-    answer = _evaluate_row(
-        source_id="answer",
-        formula_md=answer_formula_md,
-        rationale_md="correct answer",
-        is_correct=True,
-    )
-    rows: list[MCChoice] = []
-    if answer is not None:
-        rows.append(answer)
 
     for idx, spec in enumerate(mc_answer_specs, start=1):
         formula_md = (
@@ -727,5 +759,7 @@ def run_mc_formula_harness(
         collisions=collisions,
         row_previews=row_previews,
         warnings=warnings,
-        correct_answer_md=answer.content_md if answer is not None else "",
+        correct_answer_md=(
+            _format_value(answer_value).strip() if answer_value is not None else ""
+        ),
     )

--- a/src/exam_helper/templates/question_form_v2.html
+++ b/src/exam_helper/templates/question_form_v2.html
@@ -301,29 +301,20 @@
         </div>
 
         <div id="mc_block" class="card">
-          <label>Multiple Choice Answers</label>
+          <label>Multiple Choice Distractors</label>
           <p class="hint">The correct answer is pulled from the main answer formula. Fill in four distractor formulas and rationales below.</p>
-          <div class="row" style="align-items: start; margin-top: 0.5rem;">
-            <div class="card preview">
-              <strong>Correct Answer (auto-fed)</strong>
-              <div id="mc_correct_answer_md" aria-readonly="true">{{ mc_correct_answer_md if question else '' }}</div>
-            </div>
-            <div class="card">
-              <strong>Distractor Rows</strong>
-              <div class="mc-answer-list" style="margin-top: 0.75rem;">
-                {% for row in mc_answer_rows %}
-                  <div class="card mc-answer-row" data-mc-row="{{ loop.index0 }}">
-                    <p class="mc-row-title">{{ row.label }}</p>
-                    <label for="mc_answer_{{ loop.index }}_formula_md">SymPy Formula</label>
-                    <textarea id="mc_answer_{{ loop.index }}_formula_md" data-mc-formula name="mc_answer_{{ loop.index }}_formula_md">{{ row.formula_md }}</textarea>
-                    <label for="mc_answer_{{ loop.index }}_rationale_md">Rationale</label>
-                    <textarea id="mc_answer_{{ loop.index }}_rationale_md" data-mc-rationale name="mc_answer_{{ loop.index }}_rationale_md">{{ row.rationale_md }}</textarea>
-                    <div class="formula-preview" id="mc_answer_{{ loop.index }}_preview" aria-readonly="true">{{ row.preview_md }}</div>
-                    <p class="mc-row-warning" id="mc_answer_{{ loop.index }}_warning">{{ row.warning }}</p>
-                  </div>
-                {% endfor %}
+          <div class="mc-answer-list" style="margin-top: 0.75rem;">
+            {% for row in mc_answer_rows %}
+              <div class="card mc-answer-row" data-mc-row="{{ loop.index0 }}">
+                <p class="mc-row-title">Distractor {{ loop.index }}</p>
+                <label for="mc_answer_{{ loop.index }}_formula_md">SymPy Formula</label>
+                <textarea id="mc_answer_{{ loop.index }}_formula_md" data-mc-formula name="mc_answer_{{ loop.index }}_formula_md">{{ row.formula_md }}</textarea>
+                <label for="mc_answer_{{ loop.index }}_rationale_md">Rationale</label>
+                <textarea id="mc_answer_{{ loop.index }}_rationale_md" data-mc-rationale name="mc_answer_{{ loop.index }}_rationale_md">{{ row.rationale_md }}</textarea>
+                <div class="formula-preview" id="mc_answer_{{ loop.index }}_preview" aria-readonly="true">{{ row.preview_md }}</div>
+                <p class="mc-row-warning" id="mc_answer_{{ loop.index }}_warning">{{ row.warning }}</p>
               </div>
-            </div>
+            {% endfor %}
           </div>
           <div class="mc-preview-grid" style="margin-top: 0.8rem;">
             <div class="card preview">
@@ -379,7 +370,6 @@
       const figureFileInput = document.getElementById("figure_file_input");
       const promptPreview = document.getElementById("prompt_preview");
       const mcBlock = document.getElementById("mc_block");
-      const mcCorrectAnswerEl = document.getElementById("mc_correct_answer_md");
       const mcPreviewAnswers = document.getElementById("mc_preview_answers");
       const mcPreviewRationale = document.getElementById("mc_preview_rationale");
       const mcPreviewWarning = document.getElementById("mc_preview_warning");
@@ -591,7 +581,6 @@
           mcPreviewAnswers.innerHTML = "";
           mcPreviewRationale.innerHTML = "";
           mcPreviewWarning.textContent = "";
-          mcCorrectAnswerEl.textContent = "";
           Array.from(document.querySelectorAll("[id$='_preview']")).forEach((el) => {
             if (el.id.startsWith("mc_answer_")) {
               el.textContent = "";
@@ -600,12 +589,7 @@
           return;
         }
         const rows = Array.isArray(data?.mc_preview_rows) ? data.mc_preview_rows : [];
-        const correct = typeof data?.mc_correct_answer_md === "string" ? data.mc_correct_answer_md : "";
-        const answers = typeof data?.mc_preview_answers === "string" ? data.mc_preview_answers : "";
-        const rationale = typeof data?.mc_preview_rationale === "string" ? data.mc_preview_rationale : "";
-        mcCorrectAnswerEl.innerHTML = correct ? marked.parse(normalizeMathDelimitersForPreview(correct)) : "";
-        mcPreviewAnswers.innerHTML = answers ? marked.parse(normalizeMathDelimitersForPreview(answers)) : "";
-        mcPreviewRationale.innerHTML = rationale ? marked.parse(normalizeMathDelimitersForPreview(rationale)) : "";
+        const choices = Array.isArray(data?.mc_preview_choices) ? data.mc_preview_choices : [];
         mcPreviewWarning.textContent = data?.mc_preview_warning ? `Warning: ${data.mc_preview_warning}` : "";
         document.querySelectorAll("[data-mc-row]").forEach((row, idx) => {
           const previewEl = document.getElementById(`mc_answer_${idx + 1}_preview`);
@@ -628,8 +612,32 @@
             warningEl.textContent = row?.warning ? `Warning: ${row.warning}` : "";
           }
         });
+        const previewAnswersHtml = choices.map((choice) => {
+          const label = escapeHtml(String(choice.label || "?"));
+          const content = marked.parseInline(
+            normalizeMathDelimitersForPreview(
+              stripDisallowedBold(String(choice.content_md || ""))
+            )
+          );
+          return `<div><strong>${label}.</strong> <span>${content}</span></div>`;
+        }).join("");
+        const previewRationaleHtml = choices.map((choice) => {
+          const label = escapeHtml(String(choice.label || "?"));
+          const content = marked.parseInline(
+            normalizeMathDelimitersForPreview(
+              stripDisallowedBold(String(choice.content_md || ""))
+            )
+          );
+          const rationaleText = stripDisallowedBold(String(choice.rationale || ""));
+          const rationale = rationaleText
+            ? `<div><em>${marked.parseInline(normalizeMathDelimitersForPreview(rationaleText))}</em></div>`
+            : "";
+          return `<div><strong>${label}.</strong> <span>${content}</span>${rationale}</div>`;
+        }).join("");
+        mcPreviewAnswers.innerHTML = previewAnswersHtml;
+        mcPreviewRationale.innerHTML = previewRationaleHtml;
         if (window.MathJax && window.MathJax.typesetPromise) {
-          window.MathJax.typesetPromise([mcCorrectAnswerEl, mcPreviewAnswers, mcPreviewRationale]);
+          window.MathJax.typesetPromise([mcPreviewAnswers, mcPreviewRationale]);
           rows.forEach((_, idx) => {
             const previewEl = document.getElementById(`mc_answer_${idx + 1}_preview`);
             if (previewEl) {
@@ -798,10 +806,7 @@
       renderTemplate();
       syncMCSpecsFromDOM();
       renderMCPreviewFromData({
-        mc_correct_answer_md: mcCorrectAnswerEl.textContent || "",
-        mc_preview_answers: mcPreviewAnswers.textContent || "",
-        mc_preview_rationale: mcPreviewRationale.textContent || "",
-        mc_preview_warning: mcPreviewWarning.textContent || "",
+        mc_preview_choices: {{ mc_preview_choices | tojson }},
         mc_preview_rows: Array.from(document.querySelectorAll("[data-mc-row]")).map((row, idx) => {
           const preview = document.getElementById(`mc_answer_${idx + 1}_preview`);
           const warning = document.getElementById(`mc_answer_${idx + 1}_warning`);

--- a/src/exam_helper/templates/question_form_v2.html
+++ b/src/exam_helper/templates/question_form_v2.html
@@ -697,9 +697,9 @@
           renderMarkdownSurface(renderedAnswerEl, data.rendered_answer_md);
         }
         renderMCPreviewFromData(data);
-        const combinedWarning = [data.warning, data.mc_preview_warning].filter(Boolean).join(" | ");
-        answerFormulaWarningEl.textContent = combinedWarning ? `Warning: ${combinedWarning}` : "";
-        setStatus(combinedWarning ? "Saved with warning" : "Saved", combinedWarning ? "warn" : "good");
+        answerFormulaWarningEl.textContent = data.warning ? `Warning: ${data.warning}` : "";
+        const statusWarning = [data.warning, data.mc_preview_warning].filter(Boolean).join(" | ");
+        setStatus(statusWarning ? "Saved with warning" : "Saved", statusWarning ? "warn" : "good");
       }
 
       function scheduleAutosave() {

--- a/src/exam_helper/templates/question_form_v2.html
+++ b/src/exam_helper/templates/question_form_v2.html
@@ -267,8 +267,8 @@
             <textarea name="answer_guidance" id="answer_guidance">{{ answer_guidance if question else '' }}</textarea>
           </div>
           <div class="card">
-            <label for="typed_solution_md">Markdown Answer</label>
-            <textarea name="typed_solution_md" id="typed_solution_md" readonly>{{ rendered_answer_md if question else '' }}</textarea>
+            <label for="rendered_answer_md">Markdown Answer</label>
+            <textarea id="rendered_answer_md" readonly>{{ rendered_answer_md if question else '' }}</textarea>
           </div>
         </div>
 
@@ -289,7 +289,7 @@
 
         <div class="card preview">
           <strong>Markdown Answer Preview</strong>
-          <div id="typed_solution_preview"></div>
+          <div id="rendered_answer_preview"></div>
         </div>
 
         <div class="card" id="figures_section">
@@ -322,7 +322,7 @@
       const mcOptionsGuidanceEl = document.getElementById("mc_options_guidance");
       const distractorFnsEl = document.getElementById("distractor_functions_text");
       const choicesEl = document.getElementById("choices_yaml");
-      const typedSolutionEl = document.getElementById("typed_solution_md");
+      const renderedAnswerEl = document.getElementById("rendered_answer_md");
       const calculatedVariablesEl = document.getElementById("calculated_variables_md");
       const answerFormulaWarningEl = document.getElementById("answer_formula_warning");
       const typedStatusEl = document.getElementById("typed_solution_status");
@@ -335,7 +335,7 @@
       const mcBlock = document.getElementById("mc_block");
       const mcPreviewAnswers = document.getElementById("mc_preview_answers");
       const mcPreviewRationale = document.getElementById("mc_preview_rationale");
-      const typedPreview = document.getElementById("typed_solution_preview");
+      const renderedAnswerPreview = document.getElementById("rendered_answer_preview");
 
       let autosaveTimer = null;
 
@@ -552,10 +552,12 @@
         }
       }
 
-      function renderTypedPreview() {
-        typedPreview.innerHTML = marked.parse(normalizeMathDelimitersForPreview(typedSolutionEl.value || ""));
+      function renderAnswerPreview() {
+        renderedAnswerPreview.innerHTML = marked.parse(
+          normalizeMathDelimitersForPreview(renderedAnswerEl.value || "")
+        );
         if (window.MathJax && window.MathJax.typesetPromise) {
-          window.MathJax.typesetPromise([typedPreview]);
+          window.MathJax.typesetPromise([renderedAnswerPreview]);
         }
       }
 
@@ -574,7 +576,6 @@
           mc_options_guidance: mcOptionsGuidanceEl.value,
           distractor_functions_text: distractorFnsEl.value,
           choices_yaml: choicesEl.value,
-          typed_solution_md: typedSolutionEl.value,
           typed_solution_status: typedStatusEl.value,
           figures_json: figuresInput.value || "[]",
           points: Number(pointsEl.value || 5),
@@ -599,12 +600,10 @@
           calculatedVariablesEl.value = data.calculated_variables_md;
         }
         if (typeof data.rendered_answer_md === "string") {
-          if (data.rendered_answer_md || !data.warning) {
-            typedSolutionEl.value = data.rendered_answer_md;
-          }
+          renderedAnswerEl.value = data.rendered_answer_md;
         }
         answerFormulaWarningEl.textContent = data.warning ? `Warning: ${data.warning}` : "";
-        renderTypedPreview();
+        renderAnswerPreview();
         setStatus(data.warning ? "Saved with warning" : "Saved", data.warning ? "warn" : "good");
       }
 
@@ -616,14 +615,14 @@
         }, 1200);
       }
 
-      [questionTypeEl, titleEl, templateEl, paramsEl, answerFormulaEl, answerGuidanceEl, choicesEl, typedSolutionEl, pointsEl].forEach((el) => {
+      [questionTypeEl, titleEl, templateEl, paramsEl, answerFormulaEl, answerGuidanceEl, choicesEl, renderedAnswerEl, pointsEl].forEach((el) => {
         el.addEventListener("input", () => {
           if (el === answerFormulaEl) {
             answerFormulaWarningEl.textContent = "";
           }
           renderTemplate();
           renderMCPreview();
-          renderTypedPreview();
+          renderAnswerPreview();
           updateMCVisibility();
           scheduleAutosave();
         });
@@ -705,7 +704,7 @@
 
       renderTemplate();
       renderMCPreview();
-      renderTypedPreview();
+      renderAnswerPreview();
       updateMCVisibility();
       renderFiguresPreview();
     </script>

--- a/src/exam_helper/templates/question_form_v2.html
+++ b/src/exam_helper/templates/question_form_v2.html
@@ -182,6 +182,27 @@
         grid-template-columns: 1fr 1fr;
         gap: 1rem;
       }
+      .mc-answer-list {
+        display: grid;
+        gap: 0.85rem;
+      }
+      .mc-answer-row {
+        display: grid;
+        gap: 0.65rem;
+      }
+      .mc-answer-row textarea {
+        min-height: 100px;
+      }
+      .mc-row-title {
+        margin: 0;
+        font-weight: 700;
+        color: var(--text);
+      }
+      .mc-row-warning {
+        color: var(--warn);
+        font-size: 0.92rem;
+        min-height: 1.1rem;
+      }
       @media (max-width: 900px) {
         .row, .row3, .mc-preview-grid {
           grid-template-columns: 1fr;
@@ -212,6 +233,7 @@
       <form method="post" action="/questions/save" id="question-form">
         <textarea hidden name="mc_options_guidance" id="mc_options_guidance">{{ question.mc_options_guidance if question else '' }}</textarea>
         <textarea hidden name="distractor_functions_text" id="distractor_functions_text">{{ distractor_functions_text }}</textarea>
+        <textarea hidden name="mc_answer_specs_json" id="mc_answer_specs_json">{{ mc_answer_specs_json }}</textarea>
         <textarea hidden name="typed_solution_status" id="typed_solution_status">{{ question.solution.typed_solution_status if question else 'missing' }}</textarea>
         <div class="row3">
           <div class="card">
@@ -279,18 +301,41 @@
         </div>
 
         <div id="mc_block" class="card">
-          <label>MC Choices YAML (A-E)</label>
-          <textarea name="choices_yaml" id="choices_yaml">{{ choices_yaml }}</textarea>
+          <label>Multiple Choice Answers</label>
+          <p class="hint">The correct answer is pulled from the main answer formula. Fill in four distractor formulas and rationales below.</p>
+          <div class="row" style="align-items: start; margin-top: 0.5rem;">
+            <div class="card preview">
+              <strong>Correct Answer (auto-fed)</strong>
+              <div id="mc_correct_answer_md" aria-readonly="true">{{ mc_correct_answer_md if question else '' }}</div>
+            </div>
+            <div class="card">
+              <strong>Distractor Rows</strong>
+              <div class="mc-answer-list" style="margin-top: 0.75rem;">
+                {% for row in mc_answer_rows %}
+                  <div class="card mc-answer-row" data-mc-row="{{ loop.index0 }}">
+                    <p class="mc-row-title">{{ row.label }}</p>
+                    <label for="mc_answer_{{ loop.index }}_formula_md">SymPy Formula</label>
+                    <textarea id="mc_answer_{{ loop.index }}_formula_md" data-mc-formula name="mc_answer_{{ loop.index }}_formula_md">{{ row.formula_md }}</textarea>
+                    <label for="mc_answer_{{ loop.index }}_rationale_md">Rationale</label>
+                    <textarea id="mc_answer_{{ loop.index }}_rationale_md" data-mc-rationale name="mc_answer_{{ loop.index }}_rationale_md">{{ row.rationale_md }}</textarea>
+                    <div class="formula-preview" id="mc_answer_{{ loop.index }}_preview" aria-readonly="true">{{ row.preview_md }}</div>
+                    <p class="mc-row-warning" id="mc_answer_{{ loop.index }}_warning">{{ row.warning }}</p>
+                  </div>
+                {% endfor %}
+              </div>
+            </div>
+          </div>
           <div class="mc-preview-grid" style="margin-top: 0.8rem;">
             <div class="card preview">
               <strong>MC Preview (Answers)</strong>
-              <div id="mc_preview_answers"></div>
+              <div id="mc_preview_answers">{{ mc_preview_answers if question else '' }}</div>
             </div>
             <div class="card preview">
               <strong>MC Preview (Answers + Explanations)</strong>
-              <div id="mc_preview_rationale"></div>
+              <div id="mc_preview_rationale">{{ mc_preview_rationale if question else '' }}</div>
             </div>
           </div>
+          <p class="hint" id="mc_preview_warning">{{ mc_preview_warning if question else '' }}</p>
         </div>
 
         <div class="card" id="figures_section">
@@ -322,7 +367,7 @@
       const answerGuidanceEl = document.getElementById("answer_guidance");
       const mcOptionsGuidanceEl = document.getElementById("mc_options_guidance");
       const distractorFnsEl = document.getElementById("distractor_functions_text");
-      const choicesEl = document.getElementById("choices_yaml");
+      const mcAnswerSpecsEl = document.getElementById("mc_answer_specs_json");
       const renderedAnswerEl = document.getElementById("rendered_answer_md");
       const calculatedVariablesEl = document.getElementById("calculated_variables_md");
       const answerFormulaWarningEl = document.getElementById("answer_formula_warning");
@@ -334,8 +379,10 @@
       const figureFileInput = document.getElementById("figure_file_input");
       const promptPreview = document.getElementById("prompt_preview");
       const mcBlock = document.getElementById("mc_block");
+      const mcCorrectAnswerEl = document.getElementById("mc_correct_answer_md");
       const mcPreviewAnswers = document.getElementById("mc_preview_answers");
       const mcPreviewRationale = document.getElementById("mc_preview_rationale");
+      const mcPreviewWarning = document.getElementById("mc_preview_warning");
       let autosaveTimer = null;
 
       function setStatus(text, cls) {
@@ -513,41 +560,82 @@
           .replace(/<\/?b>/gi, "");
       }
 
-      function renderMCPreview() {
+      function parseMCSpecs() {
+        try {
+          const parsed = JSON.parse(mcAnswerSpecsEl.value || "[]");
+          return Array.isArray(parsed) ? parsed : [];
+        } catch {
+          return [];
+        }
+      }
+
+      function syncMCSpecsFromDOM() {
+        if (!isMC()) {
+          mcAnswerSpecsEl.value = "[]";
+          return [];
+        }
+        const specs = Array.from(document.querySelectorAll("[data-mc-row]")).map((row) => {
+          const formula = row.querySelector("[data-mc-formula]");
+          const rationale = row.querySelector("[data-mc-rationale]");
+          return {
+            formula_md: formula ? formula.value : "",
+            rationale_md: rationale ? rationale.value : "",
+          };
+        });
+        mcAnswerSpecsEl.value = JSON.stringify(specs);
+        return specs;
+      }
+
+      function renderMCPreviewFromData(data) {
         if (!isMC()) {
           mcPreviewAnswers.innerHTML = "";
           mcPreviewRationale.innerHTML = "";
+          mcPreviewWarning.textContent = "";
+          mcCorrectAnswerEl.textContent = "";
+          Array.from(document.querySelectorAll("[id$='_preview']")).forEach((el) => {
+            if (el.id.startsWith("mc_answer_")) {
+              el.textContent = "";
+            }
+          });
           return;
         }
-        let choices = [];
-        try {
-          choices = jsyaml.load(choicesEl.value || "[]") || [];
-        } catch {
-          mcPreviewAnswers.innerHTML = "<em>Invalid YAML</em>";
-          mcPreviewRationale.innerHTML = "<em>Invalid YAML</em>";
-          return;
-        }
-        choices = choices.slice().sort((a, b) => String(a.label || "").localeCompare(String(b.label || "")));
-        mcPreviewAnswers.innerHTML = choices.map((c) => {
-          const content = stripDisallowedBold(String(c.content_md || "")).split("\n")[0];
-          const text = marked.parseInline(normalizeMathDelimitersForPreview(content));
-          const label = c.is_correct
-            ? `<strong>${String(c.label || "?")}.</strong>`
-            : `<span>${String(c.label || "?")}.</span>`;
-          return `<div>${label} <span>${text}</span></div>`;
-        }).join("");
-        mcPreviewRationale.innerHTML = choices.map((c) => {
-          const content = stripDisallowedBold(String(c.content_md || ""));
-          const text = marked.parseInline(normalizeMathDelimitersForPreview(content));
-          const label = c.is_correct
-            ? `<strong>${String(c.label || "?")}.</strong>`
-            : `<span>${String(c.label || "?")}.</span>`;
-          const rationaleText = stripDisallowedBold(String(c.rationale || ""));
-          const rationale = c.rationale ? `<div><em>${marked.parseInline(normalizeMathDelimitersForPreview(rationaleText))}</em></div>` : "";
-          return `<div>${label} <span>${text}</span>${rationale}</div>`;
-        }).join("");
+        const rows = Array.isArray(data?.mc_preview_rows) ? data.mc_preview_rows : [];
+        const correct = typeof data?.mc_correct_answer_md === "string" ? data.mc_correct_answer_md : "";
+        const answers = typeof data?.mc_preview_answers === "string" ? data.mc_preview_answers : "";
+        const rationale = typeof data?.mc_preview_rationale === "string" ? data.mc_preview_rationale : "";
+        mcCorrectAnswerEl.innerHTML = correct ? marked.parse(normalizeMathDelimitersForPreview(correct)) : "";
+        mcPreviewAnswers.innerHTML = answers ? marked.parse(normalizeMathDelimitersForPreview(answers)) : "";
+        mcPreviewRationale.innerHTML = rationale ? marked.parse(normalizeMathDelimitersForPreview(rationale)) : "";
+        mcPreviewWarning.textContent = data?.mc_preview_warning ? `Warning: ${data.mc_preview_warning}` : "";
+        document.querySelectorAll("[data-mc-row]").forEach((row, idx) => {
+          const previewEl = document.getElementById(`mc_answer_${idx + 1}_preview`);
+          const warningEl = document.getElementById(`mc_answer_${idx + 1}_warning`);
+          if (previewEl) {
+            previewEl.innerHTML = "";
+          }
+          if (warningEl) {
+            warningEl.textContent = "";
+          }
+        });
+        rows.forEach((row, idx) => {
+          const previewEl = document.getElementById(`mc_answer_${idx + 1}_preview`);
+          const warningEl = document.getElementById(`mc_answer_${idx + 1}_warning`);
+          if (previewEl) {
+            const previewText = String(row?.preview_md || "");
+            previewEl.innerHTML = previewText ? marked.parse(normalizeMathDelimitersForPreview(previewText)) : "";
+          }
+          if (warningEl) {
+            warningEl.textContent = row?.warning ? `Warning: ${row.warning}` : "";
+          }
+        });
         if (window.MathJax && window.MathJax.typesetPromise) {
-          window.MathJax.typesetPromise([mcPreviewAnswers, mcPreviewRationale]);
+          window.MathJax.typesetPromise([mcCorrectAnswerEl, mcPreviewAnswers, mcPreviewRationale]);
+          rows.forEach((_, idx) => {
+            const previewEl = document.getElementById(`mc_answer_${idx + 1}_preview`);
+            if (previewEl) {
+              window.MathJax.typesetPromise([previewEl]);
+            }
+          });
         }
       }
 
@@ -563,6 +651,7 @@
       }
 
       function serializePayload() {
+        syncMCSpecsFromDOM();
         return {
           title: titleEl.value,
           question_type: questionTypeEl.value,
@@ -572,7 +661,7 @@
           answer_guidance: answerGuidanceEl.value,
           mc_options_guidance: mcOptionsGuidanceEl.value,
           distractor_functions_text: distractorFnsEl.value,
-          choices_yaml: choicesEl.value,
+          mc_answer_specs_json: mcAnswerSpecsEl.value,
           typed_solution_status: typedStatusEl.value,
           figures_json: figuresInput.value || "[]",
           points: Number(pointsEl.value || 5),
@@ -599,8 +688,10 @@
         if (typeof data.rendered_answer_md === "string") {
           renderMarkdownSurface(renderedAnswerEl, data.rendered_answer_md);
         }
-        answerFormulaWarningEl.textContent = data.warning ? `Warning: ${data.warning}` : "";
-        setStatus(data.warning ? "Saved with warning" : "Saved", data.warning ? "warn" : "good");
+        renderMCPreviewFromData(data);
+        const combinedWarning = [data.warning, data.mc_preview_warning].filter(Boolean).join(" | ");
+        answerFormulaWarningEl.textContent = combinedWarning ? `Warning: ${combinedWarning}` : "";
+        setStatus(combinedWarning ? "Saved with warning" : "Saved", combinedWarning ? "warn" : "good");
       }
 
       function scheduleAutosave() {
@@ -611,14 +702,21 @@
         }, 1200);
       }
 
-      [questionTypeEl, titleEl, templateEl, paramsEl, answerFormulaEl, answerGuidanceEl, choicesEl, pointsEl].forEach((el) => {
+      [questionTypeEl, titleEl, templateEl, paramsEl, answerFormulaEl, answerGuidanceEl, pointsEl].forEach((el) => {
         el.addEventListener("input", () => {
           if (el === answerFormulaEl) {
             answerFormulaWarningEl.textContent = "";
           }
           renderTemplate();
-          renderMCPreview();
+          syncMCSpecsFromDOM();
           updateMCVisibility();
+          scheduleAutosave();
+        });
+      });
+
+      document.querySelectorAll("[data-mc-row] textarea").forEach((el) => {
+        el.addEventListener("input", () => {
+          syncMCSpecsFromDOM();
           scheduleAutosave();
         });
       });
@@ -698,7 +796,21 @@
       });
 
       renderTemplate();
-      renderMCPreview();
+      syncMCSpecsFromDOM();
+      renderMCPreviewFromData({
+        mc_correct_answer_md: mcCorrectAnswerEl.textContent || "",
+        mc_preview_answers: mcPreviewAnswers.textContent || "",
+        mc_preview_rationale: mcPreviewRationale.textContent || "",
+        mc_preview_warning: mcPreviewWarning.textContent || "",
+        mc_preview_rows: Array.from(document.querySelectorAll("[data-mc-row]")).map((row, idx) => {
+          const preview = document.getElementById(`mc_answer_${idx + 1}_preview`);
+          const warning = document.getElementById(`mc_answer_${idx + 1}_warning`);
+          return {
+            preview_md: preview ? preview.textContent || "" : "",
+            warning: warning ? warning.textContent || "" : "",
+          };
+        }),
+      });
       renderMarkdownSurface(renderedAnswerEl, renderedAnswerEl.textContent || "");
       updateMCVisibility();
       renderFiguresPreview();

--- a/src/exam_helper/templates/question_form_v2.html
+++ b/src/exam_helper/templates/question_form_v2.html
@@ -204,8 +204,6 @@
       </div>
 
       <form method="post" action="/questions/save" id="question-form">
-        <textarea hidden name="answer_guidance" id="answer_guidance">{{ question.solution.answer_guidance if question else '' }}</textarea>
-        <textarea hidden name="answer_python_code" id="answer_python_code">{{ question.solution.answer_python_code if question else '' }}</textarea>
         <textarea hidden name="mc_options_guidance" id="mc_options_guidance">{{ question.mc_options_guidance if question else '' }}</textarea>
         <textarea hidden name="distractor_functions_text" id="distractor_functions_text">{{ distractor_functions_text }}</textarea>
         <textarea hidden name="typed_solution_status" id="typed_solution_status">{{ question.solution.typed_solution_status if question else 'missing' }}</textarea>
@@ -249,6 +247,31 @@
           <textarea name="solution_parameters_yaml" id="solution_parameters_yaml">{{ solution_parameters_yaml if question else 'dummy: 5' }}</textarea>
         </div>
 
+        <div class="row">
+          <div class="card">
+            <label for="answer_formula_md">Answer Formula (SymPy)</label>
+            <p class="hint">Write one assignment or expression per line. Parameters can be referenced by name, and the final value should end up in <code>answer</code>.</p>
+            <textarea name="answer_formula_md" id="answer_formula_md">{{ answer_formula_md if question else '' }}</textarea>
+            <p class="hint" id="answer_formula_warning">{{ answer_formula_warning if question else '' }}</p>
+          </div>
+          <div class="card">
+            <label>Calculated Variables</label>
+            <textarea id="calculated_variables_md" readonly>{{ calculated_variables_md if question else '' }}</textarea>
+          </div>
+        </div>
+
+        <div class="row">
+          <div class="card">
+            <label for="answer_guidance">Answer Text (Markdown)</label>
+            <p class="hint">Use <code>{{ '{{variable}}' }}</code> placeholders for parameters or values defined in the formula box.</p>
+            <textarea name="answer_guidance" id="answer_guidance">{{ answer_guidance if question else '' }}</textarea>
+          </div>
+          <div class="card">
+            <label for="typed_solution_md">Markdown Answer</label>
+            <textarea name="typed_solution_md" id="typed_solution_md" readonly>{{ rendered_answer_md if question else '' }}</textarea>
+          </div>
+        </div>
+
         <div id="mc_block" class="card">
           <label>MC Choices YAML (A-E)</label>
           <textarea name="choices_yaml" id="choices_yaml">{{ choices_yaml }}</textarea>
@@ -264,15 +287,9 @@
           </div>
         </div>
 
-        <div class="row">
-          <div class="card">
-            <label>Typed Solution</label>
-            <textarea name="typed_solution_md" id="typed_solution_md">{{ question.solution.typed_solution_md if question else '' }}</textarea>
-          </div>
-          <div class="card preview">
-            <strong>Typed Solution Preview</strong>
-            <div id="typed_solution_preview"></div>
-          </div>
+        <div class="card preview">
+          <strong>Markdown Answer Preview</strong>
+          <div id="typed_solution_preview"></div>
         </div>
 
         <div class="card" id="figures_section">
@@ -300,12 +317,14 @@
       const pointsEl = document.getElementById("points");
       const templateEl = document.getElementById("question_template_md");
       const paramsEl = document.getElementById("solution_parameters_yaml");
+      const answerFormulaEl = document.getElementById("answer_formula_md");
       const answerGuidanceEl = document.getElementById("answer_guidance");
-      const answerCodeEl = document.getElementById("answer_python_code");
       const mcOptionsGuidanceEl = document.getElementById("mc_options_guidance");
       const distractorFnsEl = document.getElementById("distractor_functions_text");
       const choicesEl = document.getElementById("choices_yaml");
       const typedSolutionEl = document.getElementById("typed_solution_md");
+      const calculatedVariablesEl = document.getElementById("calculated_variables_md");
+      const answerFormulaWarningEl = document.getElementById("answer_formula_warning");
       const typedStatusEl = document.getElementById("typed_solution_status");
       const figuresInput = document.getElementById("figures_json");
       const figuresPreviewEl = document.getElementById("figures_preview");
@@ -550,8 +569,8 @@
           question_type: questionTypeEl.value,
           question_template_md: templateEl.value,
           solution_parameters_yaml: paramsEl.value,
+          answer_formula_md: answerFormulaEl.value,
           answer_guidance: answerGuidanceEl.value,
-          answer_python_code: answerCodeEl.value,
           mc_options_guidance: mcOptionsGuidanceEl.value,
           distractor_functions_text: distractorFnsEl.value,
           choices_yaml: choicesEl.value,
@@ -576,7 +595,17 @@
           setStatus(`Save error: ${data.error || res.statusText}`, "warn");
           throw new Error(data.error || res.statusText);
         }
-        setStatus("Saved", "good");
+        if (typeof data.calculated_variables_md === "string") {
+          calculatedVariablesEl.value = data.calculated_variables_md;
+        }
+        if (typeof data.rendered_answer_md === "string") {
+          if (data.rendered_answer_md || !data.warning) {
+            typedSolutionEl.value = data.rendered_answer_md;
+          }
+        }
+        answerFormulaWarningEl.textContent = data.warning ? `Warning: ${data.warning}` : "";
+        renderTypedPreview();
+        setStatus(data.warning ? "Saved with warning" : "Saved", data.warning ? "warn" : "good");
       }
 
       function scheduleAutosave() {
@@ -587,8 +616,11 @@
         }, 1200);
       }
 
-      [questionTypeEl, titleEl, templateEl, paramsEl, choicesEl, typedSolutionEl, pointsEl].forEach((el) => {
+      [questionTypeEl, titleEl, templateEl, paramsEl, answerFormulaEl, answerGuidanceEl, choicesEl, typedSolutionEl, pointsEl].forEach((el) => {
         el.addEventListener("input", () => {
+          if (el === answerFormulaEl) {
+            answerFormulaWarningEl.textContent = "";
+          }
           renderTemplate();
           renderMCPreview();
           renderTypedPreview();

--- a/src/exam_helper/templates/question_form_v2.html
+++ b/src/exam_helper/templates/question_form_v2.html
@@ -78,9 +78,6 @@
         padding: 1rem;
         box-shadow: 0 10px 30px rgba(72, 52, 24, 0.06);
       }
-      .card.readonly-card {
-        background: var(--surface-strong);
-      }
       .card h2,
       .card strong {
         color: var(--text);
@@ -118,29 +115,9 @@
         min-height: 140px;
         overflow: auto;
       }
-      .preview-surface {
-        background: #f5d889;
-        border: 1px solid rgba(154, 52, 18, 0.15);
-        border-radius: 12px;
-        min-height: 140px;
-        max-height: 220px;
-        overflow: auto;
-        padding: 0.75rem;
-      }
-      .preview-surface h1,
-      .preview-surface h2,
-      .preview-surface h3,
-      .preview-surface h4,
-      .preview-surface h5,
-      .preview-surface h6 {
-        margin-top: 0.4rem;
-      }
-      .preview-surface p:first-child,
-      .preview-surface ul:first-child,
-      .preview-surface ol:first-child {
-        margin-top: 0;
-      }
       .formula-preview {
+        min-height: 140px;
+        overflow: auto;
         white-space: pre-wrap;
         font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
       }
@@ -283,9 +260,9 @@
             <textarea name="answer_formula_md" id="answer_formula_md">{{ answer_formula_md if question else '' }}</textarea>
             <p class="hint" id="answer_formula_warning">{{ answer_formula_warning if question else '' }}</p>
           </div>
-          <div class="card readonly-card">
+          <div class="card preview">
             <label>Calculated Variables</label>
-            <div id="calculated_variables_md" class="preview-surface formula-preview" aria-readonly="true">{{ calculated_variables_md if question else '' }}</div>
+            <div id="calculated_variables_md" class="formula-preview" aria-readonly="true">{{ calculated_variables_md if question else '' }}</div>
           </div>
         </div>
 
@@ -295,9 +272,9 @@
             <p class="hint">Use <code>{{ '{{variable}}' }}</code> placeholders for parameters or values defined in the formula box.</p>
             <textarea name="answer_guidance" id="answer_guidance">{{ answer_guidance if question else '' }}</textarea>
           </div>
-          <div class="card readonly-card">
+          <div class="card preview">
             <label for="rendered_answer_md">Markdown Answer</label>
-            <div id="rendered_answer_md" class="preview-surface" aria-readonly="true">{{ rendered_answer_md if question else '' }}</div>
+            <div id="rendered_answer_md" aria-readonly="true">{{ rendered_answer_md if question else '' }}</div>
           </div>
         </div>
 

--- a/src/exam_helper/templates/question_form_v2.html
+++ b/src/exam_helper/templates/question_form_v2.html
@@ -630,9 +630,9 @@
           );
           const rationaleText = stripDisallowedBold(String(choice.rationale || ""));
           const rationale = rationaleText
-            ? `<div><em>${marked.parseInline(normalizeMathDelimitersForPreview(rationaleText))}</em></div>`
+            ? ` - ${marked.parseInline(normalizeMathDelimitersForPreview(rationaleText))}`
             : "";
-          return `<div><strong>${label}.</strong> <span>${content}</span>${rationale}</div>`;
+          return `<div><strong>${label}.</strong> <span>${content}${rationale}</span></div>`;
         }).join("");
         mcPreviewAnswers.innerHTML = previewAnswersHtml;
         mcPreviewRationale.innerHTML = previewRationaleHtml;

--- a/src/exam_helper/templates/question_form_v2.html
+++ b/src/exam_helper/templates/question_form_v2.html
@@ -78,6 +78,9 @@
         padding: 1rem;
         box-shadow: 0 10px 30px rgba(72, 52, 24, 0.06);
       }
+      .card.readonly-card {
+        background: var(--surface-strong);
+      }
       .card h2,
       .card strong {
         color: var(--text);
@@ -114,6 +117,32 @@
         background: var(--surface-strong);
         min-height: 140px;
         overflow: auto;
+      }
+      .preview-surface {
+        background: #f5d889;
+        border: 1px solid rgba(154, 52, 18, 0.15);
+        border-radius: 12px;
+        min-height: 140px;
+        max-height: 220px;
+        overflow: auto;
+        padding: 0.75rem;
+      }
+      .preview-surface h1,
+      .preview-surface h2,
+      .preview-surface h3,
+      .preview-surface h4,
+      .preview-surface h5,
+      .preview-surface h6 {
+        margin-top: 0.4rem;
+      }
+      .preview-surface p:first-child,
+      .preview-surface ul:first-child,
+      .preview-surface ol:first-child {
+        margin-top: 0;
+      }
+      .formula-preview {
+        white-space: pre-wrap;
+        font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
       }
       .status {
         min-height: 1.2rem;
@@ -254,9 +283,9 @@
             <textarea name="answer_formula_md" id="answer_formula_md">{{ answer_formula_md if question else '' }}</textarea>
             <p class="hint" id="answer_formula_warning">{{ answer_formula_warning if question else '' }}</p>
           </div>
-          <div class="card">
+          <div class="card readonly-card">
             <label>Calculated Variables</label>
-            <textarea id="calculated_variables_md" readonly>{{ calculated_variables_md if question else '' }}</textarea>
+            <div id="calculated_variables_md" class="preview-surface formula-preview" aria-readonly="true">{{ calculated_variables_md if question else '' }}</div>
           </div>
         </div>
 
@@ -266,9 +295,9 @@
             <p class="hint">Use <code>{{ '{{variable}}' }}</code> placeholders for parameters or values defined in the formula box.</p>
             <textarea name="answer_guidance" id="answer_guidance">{{ answer_guidance if question else '' }}</textarea>
           </div>
-          <div class="card">
+          <div class="card readonly-card">
             <label for="rendered_answer_md">Markdown Answer</label>
-            <textarea id="rendered_answer_md" readonly>{{ rendered_answer_md if question else '' }}</textarea>
+            <div id="rendered_answer_md" class="preview-surface" aria-readonly="true">{{ rendered_answer_md if question else '' }}</div>
           </div>
         </div>
 
@@ -285,11 +314,6 @@
               <div id="mc_preview_rationale"></div>
             </div>
           </div>
-        </div>
-
-        <div class="card preview">
-          <strong>Markdown Answer Preview</strong>
-          <div id="rendered_answer_preview"></div>
         </div>
 
         <div class="card" id="figures_section">
@@ -335,8 +359,6 @@
       const mcBlock = document.getElementById("mc_block");
       const mcPreviewAnswers = document.getElementById("mc_preview_answers");
       const mcPreviewRationale = document.getElementById("mc_preview_rationale");
-      const renderedAnswerPreview = document.getElementById("rendered_answer_preview");
-
       let autosaveTimer = null;
 
       function setStatus(text, cls) {
@@ -552,12 +574,10 @@
         }
       }
 
-      function renderAnswerPreview() {
-        renderedAnswerPreview.innerHTML = marked.parse(
-          normalizeMathDelimitersForPreview(renderedAnswerEl.value || "")
-        );
+      function renderMarkdownSurface(el, markdown) {
+        el.innerHTML = marked.parse(normalizeMathDelimitersForPreview(markdown || ""));
         if (window.MathJax && window.MathJax.typesetPromise) {
-          window.MathJax.typesetPromise([renderedAnswerPreview]);
+          window.MathJax.typesetPromise([el]);
         }
       }
 
@@ -597,13 +617,12 @@
           throw new Error(data.error || res.statusText);
         }
         if (typeof data.calculated_variables_md === "string") {
-          calculatedVariablesEl.value = data.calculated_variables_md;
+          calculatedVariablesEl.textContent = data.calculated_variables_md;
         }
         if (typeof data.rendered_answer_md === "string") {
-          renderedAnswerEl.value = data.rendered_answer_md;
+          renderMarkdownSurface(renderedAnswerEl, data.rendered_answer_md);
         }
         answerFormulaWarningEl.textContent = data.warning ? `Warning: ${data.warning}` : "";
-        renderAnswerPreview();
         setStatus(data.warning ? "Saved with warning" : "Saved", data.warning ? "warn" : "good");
       }
 
@@ -615,14 +634,13 @@
         }, 1200);
       }
 
-      [questionTypeEl, titleEl, templateEl, paramsEl, answerFormulaEl, answerGuidanceEl, choicesEl, renderedAnswerEl, pointsEl].forEach((el) => {
+      [questionTypeEl, titleEl, templateEl, paramsEl, answerFormulaEl, answerGuidanceEl, choicesEl, pointsEl].forEach((el) => {
         el.addEventListener("input", () => {
           if (el === answerFormulaEl) {
             answerFormulaWarningEl.textContent = "";
           }
           renderTemplate();
           renderMCPreview();
-          renderAnswerPreview();
           updateMCVisibility();
           scheduleAutosave();
         });
@@ -704,7 +722,7 @@
 
       renderTemplate();
       renderMCPreview();
-      renderAnswerPreview();
+      renderMarkdownSurface(renderedAnswerEl, renderedAnswerEl.textContent || "");
       updateMCVisibility();
       renderFiguresPreview();
     </script>

--- a/src/exam_helper/validation.py
+++ b/src/exam_helper/validation.py
@@ -4,17 +4,17 @@ from exam_helper.models import Question
 from exam_helper.repository import ProjectRepository
 from exam_helper.solution_runtime import (
     SolutionRuntimeError,
-    run_answer_function,
+    run_answer_formula,
     run_distractor_function,
 )
 
 
 def validate_question(question: Question) -> list[str]:
     errors: list[str] = []
-    if question.solution.answer_python_code.strip():
+    if question.solution.answer_formula_md.strip():
         try:
-            run_answer_function(
-                question.solution.answer_python_code, question.solution.parameters
+            run_answer_formula(
+                question.solution.answer_formula_md, question.solution.parameters
             )
         except SolutionRuntimeError as ex:
             errors.append(f"{question.id}: {ex}")

--- a/src/exam_helper/validation.py
+++ b/src/exam_helper/validation.py
@@ -5,6 +5,7 @@ from exam_helper.repository import ProjectRepository
 from exam_helper.solution_runtime import (
     SolutionRuntimeError,
     run_answer_formula,
+    run_mc_formula_harness,
     run_distractor_function,
 )
 
@@ -19,17 +20,35 @@ def validate_question(question: Question) -> list[str]:
         except SolutionRuntimeError as ex:
             errors.append(f"{question.id}: {ex}")
     if question.question_type.value == "multiple_choice":
-        if len(question.solution.distractor_python_code) != 4:
-            errors.append(
-                f"{question.id}: multiple_choice requires exactly four distractor functions."
-            )
-        for d in question.solution.distractor_python_code:
-            if not d.python_code.strip():
-                continue
-            try:
-                run_distractor_function(d.python_code, question.solution.parameters)
-            except SolutionRuntimeError as ex:
-                errors.append(f"{question.id}:{d.id}: {ex}")
+        if question.solution.mc_answer_specs:
+            if len(question.solution.mc_answer_specs) != 4:
+                errors.append(
+                    f"{question.id}: multiple_choice requires exactly four MC answer specs."
+                )
+            else:
+                try:
+                    harness = run_mc_formula_harness(
+                        question.solution.answer_formula_md,
+                        question.solution.mc_answer_specs,
+                        question.solution.parameters,
+                        strict=True,
+                    )
+                    for collision in harness.collisions:
+                        errors.append(f"{question.id}: {collision}")
+                except SolutionRuntimeError as ex:
+                    errors.append(f"{question.id}: {ex}")
+        else:
+            if len(question.solution.distractor_python_code) != 4:
+                errors.append(
+                    f"{question.id}: multiple_choice requires exactly four distractor functions."
+                )
+            for d in question.solution.distractor_python_code:
+                if not d.python_code.strip():
+                    continue
+                try:
+                    run_distractor_function(d.python_code, question.solution.parameters)
+                except SolutionRuntimeError as ex:
+                    errors.append(f"{question.id}:{d.id}: {ex}")
     return errors
 
 

--- a/tests/integration/test_app_ai_config_and_usage.py
+++ b/tests/integration/test_app_ai_config_and_usage.py
@@ -135,7 +135,7 @@ def test_prompt_preview_endpoint_returns_composed_payload(tmp_path) -> None:
             }
 
     app.state.ai = _PreviewAI()
-    resp = client.post("/questions/q2/ai/preview/generate-answer-function")
+    resp = client.post("/questions/q2/ai/preview/generate-answer-formula")
     assert resp.status_code == 200
     payload = resp.json()
     assert payload["ok"] is True

--- a/tests/integration/test_app_ai_config_and_usage.py
+++ b/tests/integration/test_app_ai_config_and_usage.py
@@ -49,6 +49,9 @@ def test_question_editor_has_new_workflow_hooks(tmp_path) -> None:
     assert "function setAiBusy(isBusy)" not in resp.text
     assert "await autosaveNow({ allowWhenBusy: true });" not in resp.text
     assert "mc_options_guidance: mcOptionsGuidanceEl.value" in resp.text
+    assert 'id="mc_answer_specs_json"' in resp.text
+    assert 'id="mc_answer_1_formula_md"' in resp.text
+    assert "MC Choices YAML" not in resp.text
     assert "AI request in progress; editing is temporarily disabled." not in resp.text
 
     redirect = client.get("/questions/q_edit/edit", follow_redirects=False)

--- a/tests/integration/test_app_ai_config_and_usage.py
+++ b/tests/integration/test_app_ai_config_and_usage.py
@@ -51,7 +51,8 @@ def test_question_editor_has_new_workflow_hooks(tmp_path) -> None:
     assert "mc_options_guidance: mcOptionsGuidanceEl.value" in resp.text
     assert 'id="mc_answer_specs_json"' in resp.text
     assert 'id="mc_answer_1_formula_md"' in resp.text
-    assert "MC Choices YAML" not in resp.text
+    assert "Multiple Choice Distractors" in resp.text
+    assert "Correct Answer (auto-fed)" not in resp.text
     assert "AI request in progress; editing is temporarily disabled." not in resp.text
 
     redirect = client.get("/questions/q_edit/edit", follow_redirects=False)

--- a/tests/integration/test_app_question_save.py
+++ b/tests/integration/test_app_question_save.py
@@ -138,7 +138,7 @@ def test_new_question_2_page_contains_simplified_editor(tmp_path) -> None:
     assert 'id="answer_formula_md"' in html
     assert 'id="calculated_variables_md"' in html
     assert 'id="answer_guidance"' in html
-    assert 'id="typed_solution_md"' in html
+    assert 'id="rendered_answer_md"' in html
     assert 'id="btn_rewrite"' not in html
     assert 'id="btn_generate_answer"' not in html
 
@@ -178,7 +178,7 @@ def test_edit2_existing_question_save_preserves_legacy_fields(tmp_path) -> None:
     assert 'id="choices_yaml"' in edit_html
     assert 'id="answer_formula_md"' in edit_html
     assert 'id="calculated_variables_md"' in edit_html
-    assert 'id="typed_solution_md"' in edit_html
+    assert 'id="rendered_answer_md"' in edit_html
 
     save_resp = client.post(
         "/questions/save",

--- a/tests/integration/test_app_question_save.py
+++ b/tests/integration/test_app_question_save.py
@@ -135,6 +135,9 @@ def test_new_question_2_page_contains_simplified_editor(tmp_path) -> None:
     assert "New Question" in html
     assert 'id="figures_json"' in html
     assert 'id="choices_yaml"' in html
+    assert 'id="answer_formula_md"' in html
+    assert 'id="calculated_variables_md"' in html
+    assert 'id="answer_guidance"' in html
     assert 'id="typed_solution_md"' in html
     assert 'id="btn_rewrite"' not in html
     assert 'id="btn_generate_answer"' not in html
@@ -173,6 +176,8 @@ def test_edit2_existing_question_save_preserves_legacy_fields(tmp_path) -> None:
     edit_html = edit_resp.text
     assert 'id="figures_json"' in edit_html
     assert 'id="choices_yaml"' in edit_html
+    assert 'id="answer_formula_md"' in edit_html
+    assert 'id="calculated_variables_md"' in edit_html
     assert 'id="typed_solution_md"' in edit_html
 
     save_resp = client.post(
@@ -399,7 +404,7 @@ def test_autosave_persists_dollar_math_delimiters(tmp_path) -> None:
             "question_template_md": r"Given \\(v\\)",
             "solution_parameters_yaml": "{}",
             "answer_guidance": "",
-            "answer_python_code": "",
+            "answer_formula_md": "",
             "distractor_functions_text": "",
             "choices_yaml": "[]",
             "typed_solution_md": r"So \\(v=1\\).",

--- a/tests/integration/test_app_question_save.py
+++ b/tests/integration/test_app_question_save.py
@@ -134,7 +134,9 @@ def test_new_question_2_page_contains_simplified_editor(tmp_path) -> None:
     html = resp.text
     assert "New Question" in html
     assert 'id="figures_json"' in html
-    assert 'id="choices_yaml"' in html
+    assert 'id="mc_answer_specs_json"' in html
+    assert 'id="mc_answer_1_formula_md"' in html
+    assert "MC Choices YAML" not in html
     assert 'id="answer_formula_md"' in html
     assert 'id="calculated_variables_md"' in html
     assert 'id="answer_guidance"' in html
@@ -175,7 +177,9 @@ def test_edit2_existing_question_save_preserves_legacy_fields(tmp_path) -> None:
     assert edit_resp.status_code == 200
     edit_html = edit_resp.text
     assert 'id="figures_json"' in edit_html
-    assert 'id="choices_yaml"' in edit_html
+    assert 'id="mc_answer_specs_json"' in edit_html
+    assert 'id="mc_answer_1_formula_md"' in edit_html
+    assert "MC Choices YAML" not in edit_html
     assert 'id="answer_formula_md"' in edit_html
     assert 'id="calculated_variables_md"' in edit_html
     assert 'id="rendered_answer_md"' in edit_html

--- a/tests/integration/test_app_question_save.py
+++ b/tests/integration/test_app_question_save.py
@@ -136,7 +136,8 @@ def test_new_question_2_page_contains_simplified_editor(tmp_path) -> None:
     assert 'id="figures_json"' in html
     assert 'id="mc_answer_specs_json"' in html
     assert 'id="mc_answer_1_formula_md"' in html
-    assert "MC Choices YAML" not in html
+    assert "Multiple Choice Distractors" in html
+    assert "Correct Answer (auto-fed)" not in html
     assert 'id="answer_formula_md"' in html
     assert 'id="calculated_variables_md"' in html
     assert 'id="answer_guidance"' in html
@@ -179,7 +180,8 @@ def test_edit2_existing_question_save_preserves_legacy_fields(tmp_path) -> None:
     assert 'id="figures_json"' in edit_html
     assert 'id="mc_answer_specs_json"' in edit_html
     assert 'id="mc_answer_1_formula_md"' in edit_html
-    assert "MC Choices YAML" not in edit_html
+    assert "Multiple Choice Distractors" in edit_html
+    assert "Correct Answer (auto-fed)" not in edit_html
     assert 'id="answer_formula_md"' in edit_html
     assert 'id="calculated_variables_md"' in edit_html
     assert 'id="rendered_answer_md"' in edit_html

--- a/tests/integration/test_autosave_and_ai_errors.py
+++ b/tests/integration/test_autosave_and_ai_errors.py
@@ -139,23 +139,15 @@ def test_harness_run_returns_422_for_collisions(tmp_path) -> None:
             "question_template_md": "P",
             "solution_parameters_yaml": "{}",
             "answer_formula_md": "answer = 2",
-            "distractor_functions_text": (
-                "# distractor: d1\n"
-                "def distractor(params):\n"
-                "    return {'distractor_md':'2','rationale':'dup'}\n"
-                "---\n"
-                "# distractor: d2\n"
-                "def distractor(params):\n"
-                "    return {'distractor_md':'3','rationale':'r'}\n"
-                "---\n"
-                "# distractor: d3\n"
-                "def distractor(params):\n"
-                "    return {'distractor_md':'4','rationale':'r'}\n"
-                "---\n"
-                "# distractor: d4\n"
-                "def distractor(params):\n"
-                "    return {'distractor_md':'5','rationale':'r'}\n"
+            "mc_answer_specs_json": (
+                "["
+                '{"formula_md":"answer = 2","rationale_md":"dup"},'
+                '{"formula_md":"answer = 3","rationale_md":"r"},'
+                '{"formula_md":"answer = 4","rationale_md":"r"},'
+                '{"formula_md":"answer = 5","rationale_md":"r"}'
+                "]"
             ),
+            "distractor_functions_text": "",
             "choices_yaml": "[]",
             "typed_solution_md": "",
             "typed_solution_status": "missing",
@@ -167,6 +159,49 @@ def test_harness_run_returns_422_for_collisions(tmp_path) -> None:
     assert resp.status_code == 422
     assert resp.json()["ok"] is False
     assert resp.json()["collisions"]
+
+
+def test_autosave_updates_mc_formula_preview(tmp_path) -> None:
+    repo = ProjectRepository(tmp_path)
+    repo.init_project("Exam", "Physics")
+    app = create_app(tmp_path, openai_key=None)
+    client = TestClient(app)
+    _seed_question(client, "q_mc_formula", qtype="multiple_choice")
+
+    resp = client.post(
+        "/questions/q_mc_formula/autosave",
+        json={
+            "title": "T",
+            "question_type": "multiple_choice",
+            "question_template_md": "P",
+            "solution_parameters_yaml": "{}",
+            "answer_formula_md": "answer = 2",
+            "answer_guidance": "Use the result {{answer}}.",
+            "mc_options_guidance": "",
+            "mc_answer_specs_json": (
+                "["
+                '{"formula_md":"answer = 3","rationale_md":"off by one"},'
+                '{"formula_md":"answer = 4","rationale_md":"off by two"},'
+                '{"formula_md":"answer = 5","rationale_md":"off by three"},'
+                '{"formula_md":"answer = 6","rationale_md":"off by four"}'
+                "]"
+            ),
+            "distractor_functions_text": "",
+            "choices_yaml": "[]",
+            "typed_solution_md": "",
+            "typed_solution_status": "missing",
+            "figures_json": "[]",
+            "points": 5,
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["mc_correct_answer_md"] == "2"
+    assert body["mc_preview_rows"]
+    saved = repo.get_question("q_mc_formula")
+    assert saved.solution.mc_answer_specs[0].formula_md == "answer = 3"
+    assert [c.content_md for c in saved.choices][0] == "2"
 
 
 def test_generate_mc_distractors_retries_and_returns_partial_unique_set(

--- a/tests/integration/test_autosave_and_ai_errors.py
+++ b/tests/integration/test_autosave_and_ai_errors.py
@@ -183,7 +183,7 @@ def test_autosave_updates_mc_formula_preview(tmp_path) -> None:
                 '{"formula_md":"answer = 3","rationale_md":"off by one"},'
                 '{"formula_md":"answer = 4","rationale_md":"off by two"},'
                 '{"formula_md":"answer = 5","rationale_md":"off by three"},'
-                '{"formula_md":"answer = 6","rationale_md":"off by four"}'
+                '{"formula_md":"","rationale_md":"off by four"}'
                 "]"
             ),
             "distractor_functions_text": "",
@@ -202,9 +202,11 @@ def test_autosave_updates_mc_formula_preview(tmp_path) -> None:
         "B",
         "C",
         "D",
-        "E",
     ]
     assert body["mc_preview_choices"][0]["content_md"] == "2"
+    assert "Formula defines answer directly" in body["warning"]
+    assert "choice_4" not in body["warning"]
+    assert "choice_4" in body["mc_preview_warning"]
     assert body["mc_preview_rows"]
     saved = repo.get_question("q_mc_formula")
     assert saved.solution.mc_answer_specs[0].formula_md == "answer = 3"

--- a/tests/integration/test_autosave_and_ai_errors.py
+++ b/tests/integration/test_autosave_and_ai_errors.py
@@ -250,7 +250,7 @@ def test_generate_typed_solution_sets_status_fresh(tmp_path) -> None:
     assert body["typed_solution_status"] == "fresh"
 
 
-def test_generate_answer_function_retries_with_runtime_feedback(tmp_path) -> None:
+def test_generate_answer_formula_retries_with_runtime_feedback(tmp_path) -> None:
     repo = ProjectRepository(tmp_path)
     repo.init_project("Exam", "Physics")
     app = create_app(tmp_path, openai_key="k")
@@ -278,26 +278,81 @@ def test_generate_answer_function_retries_with_runtime_feedback(tmp_path) -> Non
         def __init__(self):
             self.calls = 0
 
-        def generate_answer_function(self, question, error_feedback=""):
+        def generate_answer_formula(self, question, error_feedback=""):
             self.calls += 1
             if self.calls == 1:
-                return AIService.AnswerFunctionResult(
+                return AIService.AnswerFormulaResult(
                     answer_formula_md="answer = x",
                     usage=AIUsageTotals(),
                 )
-            return AIService.AnswerFunctionResult(
+            return AIService.AnswerFormulaResult(
                 answer_formula_md="x = 1\nanswer = x",
                 usage=AIUsageTotals(),
             )
 
     fake = _AI()
     app.state.ai = fake
-    resp = client.post("/questions/q_answer_retry/ai/generate-answer-function")
+    resp = client.post("/questions/q_answer_retry/ai/generate-answer-formula")
     assert resp.status_code == 200
     data = resp.json()
     assert data["ok"] is True
     assert "answer" in data["answer_formula_md"]
     assert fake.calls == 2
+
+
+def test_autosave_keeps_last_good_answer_preview_when_formula_has_warning(
+    tmp_path,
+) -> None:
+    repo = ProjectRepository(tmp_path)
+    repo.init_project("Exam", "Physics")
+    app = create_app(tmp_path, openai_key=None)
+    client = TestClient(app)
+    _seed_question(client, "q_warning")
+
+    first = client.post(
+        "/questions/q_warning/autosave",
+        json={
+            "title": "T",
+            "question_type": "free_response",
+            "question_template_md": "P",
+            "solution_parameters_yaml": "{v: 5}",
+            "answer_formula_md": "answer = v",
+            "answer_guidance": "{{answer}}",
+            "distractor_functions_text": "",
+            "choices_yaml": "[]",
+            "typed_solution_md": "",
+            "typed_solution_status": "missing",
+            "figures_json": "[]",
+            "points": 5,
+        },
+    )
+    assert first.status_code == 200
+    assert first.json()["rendered_answer_md"] == "5"
+
+    second = client.post(
+        "/questions/q_warning/autosave",
+        json={
+            "title": "T",
+            "question_type": "free_response",
+            "question_template_md": "P",
+            "solution_parameters_yaml": "{v: 5}",
+            "answer_formula_md": "answer = missing_name",
+            "answer_guidance": "{{answer}}",
+            "distractor_functions_text": "",
+            "choices_yaml": "[]",
+            "typed_solution_md": "",
+            "typed_solution_status": "missing",
+            "figures_json": "[]",
+            "points": 5,
+        },
+    )
+    assert second.status_code == 200
+    body = second.json()
+    assert body["ok"] is True
+    assert body["warning"]
+    assert body["rendered_answer_md"] == "5"
+    saved = repo.get_question("q_warning")
+    assert saved.solution.last_computed_answer_md == "5"
 
 
 def test_harness_run_preserves_latex_backslashes_in_answer_output(tmp_path) -> None:

--- a/tests/integration/test_autosave_and_ai_errors.py
+++ b/tests/integration/test_autosave_and_ai_errors.py
@@ -197,7 +197,14 @@ def test_autosave_updates_mc_formula_preview(tmp_path) -> None:
     assert resp.status_code == 200
     body = resp.json()
     assert body["ok"] is True
-    assert body["mc_correct_answer_md"] == "2"
+    assert [choice["label"] for choice in body["mc_preview_choices"]] == [
+        "A",
+        "B",
+        "C",
+        "D",
+        "E",
+    ]
+    assert body["mc_preview_choices"][0]["content_md"] == "2"
     assert body["mc_preview_rows"]
     saved = repo.get_question("q_mc_formula")
     assert saved.solution.mc_answer_specs[0].formula_md == "answer = 3"

--- a/tests/integration/test_autosave_and_ai_errors.py
+++ b/tests/integration/test_autosave_and_ai_errors.py
@@ -213,6 +213,55 @@ def test_autosave_updates_mc_formula_preview(tmp_path) -> None:
     assert [c.content_md for c in saved.choices][0] == "2"
 
 
+def test_harness_run_keeps_correct_answer_out_of_distractor_rows(tmp_path) -> None:
+    app = create_app(tmp_path, openai_key=None)
+    client = TestClient(app)
+    _seed_question(client, "q_mc_harness_rows", qtype="multiple_choice")
+    client.post(
+        "/questions/q_mc_harness_rows/autosave",
+        json={
+            "title": "T",
+            "question_type": "multiple_choice",
+            "question_template_md": "P",
+            "solution_parameters_yaml": '{"offset": 10}',
+            "answer_formula_md": "base = 2\nanswer = base + offset",
+            "mc_answer_specs_json": (
+                "["
+                '{"formula_md":"answer = base + 1","rationale_md":"r1"},'
+                '{"formula_md":"answer = base + 2","rationale_md":"r2"},'
+                '{"formula_md":"answer = base + 3","rationale_md":"r3"},'
+                '{"formula_md":"answer = base + 4","rationale_md":"r4"}'
+                "]"
+            ),
+            "distractor_functions_text": "",
+            "choices_yaml": "[]",
+            "typed_solution_md": "",
+            "typed_solution_status": "missing",
+            "figures_json": "[]",
+            "points": 5,
+        },
+    )
+
+    resp = client.post("/questions/q_mc_harness_rows/harness/run")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+    assert [row["preview_md"] for row in body["mc_preview_rows"]] == [
+        "3",
+        "4",
+        "5",
+        "6",
+    ]
+    assert [choice["content_md"] for choice in body["mc_preview_choices"]] == [
+        "3",
+        "4",
+        "5",
+        "6",
+        "12",
+    ]
+
+
 def test_generate_mc_distractors_retries_and_returns_partial_unique_set(
     tmp_path,
 ) -> None:

--- a/tests/integration/test_autosave_and_ai_errors.py
+++ b/tests/integration/test_autosave_and_ai_errors.py
@@ -207,6 +207,7 @@ def test_autosave_updates_mc_formula_preview(tmp_path) -> None:
     assert "Formula defines answer directly" in body["warning"]
     assert "choice_4" not in body["warning"]
     assert "choice_4" in body["mc_preview_warning"]
+    assert body["mc_preview_rationale"].startswith("A. 2 -")
     assert body["mc_preview_rows"]
     saved = repo.get_question("q_mc_formula")
     assert saved.solution.mc_answer_specs[0].formula_md == "answer = 3"

--- a/tests/integration/test_autosave_and_ai_errors.py
+++ b/tests/integration/test_autosave_and_ai_errors.py
@@ -18,7 +18,7 @@ def _seed_question(client: TestClient, qid: str, qtype: str = "free_response") -
             "prompt_md": "old prompt",
             "question_template_md": "old template",
             "solution_parameters_yaml": "{}",
-            "answer_python_code": "",
+            "answer_formula_md": "",
             "distractor_functions_text": "",
             "choices_yaml": "[]",
             "typed_solution_md": "",
@@ -44,7 +44,7 @@ def test_autosave_marks_typed_solution_stale_on_parameter_change(tmp_path) -> No
             "prompt_md": "P",
             "question_template_md": "v={{v}}",
             "solution_parameters_yaml": "{v: 10}",
-            "answer_python_code": "def solve(params):\n    return {'answer_md':'10','final_answer':'10'}\n",
+            "answer_formula_md": "answer = 10",
             "distractor_functions_text": "",
             "choices_yaml": "[]",
             "typed_solution_md": "Draft",
@@ -61,7 +61,7 @@ def test_autosave_marks_typed_solution_stale_on_parameter_change(tmp_path) -> No
             "prompt_md": "P",
             "question_template_md": "v={{v}}",
             "solution_parameters_yaml": "{v: 11}",
-            "answer_python_code": "def solve(params):\n    return {'answer_md':'11','final_answer':'11'}\n",
+            "answer_formula_md": "answer = 11",
             "distractor_functions_text": "",
             "choices_yaml": "[]",
             "typed_solution_md": "Draft",
@@ -138,7 +138,7 @@ def test_harness_run_returns_422_for_collisions(tmp_path) -> None:
             "prompt_md": "P",
             "question_template_md": "P",
             "solution_parameters_yaml": "{}",
-            "answer_python_code": "def solve(params):\n    return {'answer_md':'2','final_answer':'2'}\n",
+            "answer_formula_md": "answer = 2",
             "distractor_functions_text": (
                 "# distractor: d1\n"
                 "def distractor(params):\n"
@@ -185,7 +185,7 @@ def test_generate_mc_distractors_retries_and_returns_partial_unique_set(
             "prompt_md": "P",
             "question_template_md": "P",
             "solution_parameters_yaml": "{}",
-            "answer_python_code": "def solve(params):\n    return {'answer_md':'2','final_answer':'2'}\n",
+            "answer_formula_md": "answer = 2",
             "distractor_functions_text": "",
             "choices_yaml": "[]",
             "typed_solution_md": "",
@@ -264,7 +264,7 @@ def test_generate_answer_function_retries_with_runtime_feedback(tmp_path) -> Non
             "question_template_md": "P",
             "solution_parameters_yaml": "{v: 5}",
             "answer_guidance": "",
-            "answer_python_code": "",
+            "answer_formula_md": "",
             "distractor_functions_text": "",
             "choices_yaml": "[]",
             "typed_solution_md": "",
@@ -282,11 +282,11 @@ def test_generate_answer_function_retries_with_runtime_feedback(tmp_path) -> Non
             self.calls += 1
             if self.calls == 1:
                 return AIService.AnswerFunctionResult(
-                    answer_python_code="def solve(params):\n    return {'answer_md':'x'}\n",
+                    answer_formula_md="answer = x",
                     usage=AIUsageTotals(),
                 )
             return AIService.AnswerFunctionResult(
-                answer_python_code="def solve(params):\n    return {'answer_md':'x','final_answer':'x'}\n",
+                answer_formula_md="x = 1\nanswer = x",
                 usage=AIUsageTotals(),
             )
 
@@ -296,7 +296,7 @@ def test_generate_answer_function_retries_with_runtime_feedback(tmp_path) -> Non
     assert resp.status_code == 200
     data = resp.json()
     assert data["ok"] is True
-    assert "final_answer" in data["answer_python_code"]
+    assert "answer" in data["answer_formula_md"]
     assert fake.calls == 2
 
 
@@ -314,11 +314,8 @@ def test_harness_run_preserves_latex_backslashes_in_answer_output(tmp_path) -> N
             "question_type": "free_response",
             "question_template_md": r"Use \\(\\theta\\)",
             "solution_parameters_yaml": "{}",
-            "answer_guidance": "",
-            "answer_python_code": (
-                "def solve(params):\n"
-                "    return {'answer_md': '$\\theta$', 'final_answer': '$\\lambda$'}\n"
-            ),
+            "answer_guidance": r"$\theta$",
+            "answer_formula_md": "answer = 1",
             "distractor_functions_text": "",
             "choices_yaml": "[]",
             "typed_solution_md": "",
@@ -332,7 +329,7 @@ def test_harness_run_preserves_latex_backslashes_in_answer_output(tmp_path) -> N
     assert resp.status_code == 200
     data = resp.json()
     assert data["computed_answer_md"] == r"$\theta$"
-    assert data["final_answer_text"] == r"$\lambda$"
+    assert data["final_answer_text"] == "1"
 
     saved = repo.get_question("q_latex")
     assert saved.solution.last_computed_answer_md == r"$\theta$"
@@ -353,7 +350,7 @@ def test_autosave_updates_mc_options_guidance(tmp_path) -> None:
             "mc_options_guidance": "Use realistic sign mistakes only.",
             "question_template_md": "P",
             "solution_parameters_yaml": "{}",
-            "answer_python_code": "",
+            "answer_formula_md": "",
             "distractor_functions_text": "",
             "choices_yaml": "[]",
             "typed_solution_md": "",

--- a/tests/integration/test_browser_question_roundtrip.py
+++ b/tests/integration/test_browser_question_roundtrip.py
@@ -75,11 +75,8 @@ def test_browser_question_roundtrip(tmp_path: Path) -> None:
                 "question_type": "free_response",
                 "question_template_md": "A block moves with speed {{v}} m/s.",
                 "solution_parameters_yaml": "v: 7.5",
-                "answer_guidance": "Use kinematics.",
-                "answer_python_code": (
-                    "def solve(params):\n"
-                    "    return {'answer_md':'7.5 m/s','final_answer':'7.5 m/s'}\n"
-                ),
+                "answer_formula_md": "v = float(params.get('v', 0))\nanswer = v",
+                "answer_guidance": "Use kinematics: {{v}} m/s.",
                 "mc_options_guidance": "Avoid sign-error distractors.",
                 "distractor_functions_text": "",
                 "choices_yaml": "[]",
@@ -114,17 +111,20 @@ def test_browser_question_roundtrip(tmp_path: Path) -> None:
                     page.locator("#solution_parameters_yaml").input_value().strip()
                     == "v: 7.5"
                 )
+                assert page.locator("#answer_formula_md").input_value().strip() == (
+                    "v = float(params.get('v', 0))\nanswer = v"
+                )
                 assert page.locator("#typed_solution_md").input_value() == (
-                    "It moves at 7.5 m/s."
+                    "Use kinematics: 7.5 m/s."
                 )
                 assert page.locator("#points").input_value() == "8"
                 assert (
-                    page.locator("#answer_guidance").input_value() == "Use kinematics."
+                    page.locator("#answer_guidance").input_value()
+                    == "Use kinematics: {{v}} m/s."
                 )
-                assert (
-                    page.locator("#answer_python_code").input_value()
-                    == "def solve(params):\n    return {'answer_md':'7.5 m/s','final_answer':'7.5 m/s'}\n"
-                )
+                assert page.locator(
+                    "#calculated_variables_md"
+                ).input_value().strip() == ("v = 7.5\nanswer = 7.5")
                 assert (
                     page.locator("#mc_options_guidance").input_value()
                     == "Avoid sign-error distractors."
@@ -150,18 +150,21 @@ def test_browser_question_roundtrip(tmp_path: Path) -> None:
                     page.locator("#solution_parameters_yaml").input_value().strip()
                     == "v: 7.5"
                 )
+                assert page.locator("#answer_formula_md").input_value().strip() == (
+                    "v = float(params.get('v', 0))\nanswer = v"
+                )
                 assert (
                     page.locator("#typed_solution_md").input_value()
-                    == "It moves at 7.5 m/s."
+                    == "Use kinematics: 7.5 m/s."
                 )
                 assert page.locator("#points").input_value() == "8"
                 assert (
-                    page.locator("#answer_guidance").input_value() == "Use kinematics."
+                    page.locator("#answer_guidance").input_value()
+                    == "Use kinematics: {{v}} m/s."
                 )
-                assert (
-                    page.locator("#answer_python_code").input_value()
-                    == "def solve(params):\n    return {'answer_md':'7.5 m/s','final_answer':'7.5 m/s'}\n"
-                )
+                assert page.locator(
+                    "#calculated_variables_md"
+                ).input_value().strip() == ("v = 7.5\nanswer = 7.5")
                 assert (
                     page.locator("#mc_options_guidance").input_value()
                     == "Avoid sign-error distractors."

--- a/tests/integration/test_browser_question_roundtrip.py
+++ b/tests/integration/test_browser_question_roundtrip.py
@@ -114,7 +114,7 @@ def test_browser_question_roundtrip(tmp_path: Path) -> None:
                 assert page.locator("#answer_formula_md").input_value().strip() == (
                     "v = float(v)\nanswer = v"
                 )
-                assert page.locator("#rendered_answer_md").input_value() == (
+                assert page.locator("#rendered_answer_md").inner_text() == (
                     "Use kinematics: 7.5 m/s."
                 )
                 assert page.locator("#points").input_value() == "8"
@@ -124,7 +124,7 @@ def test_browser_question_roundtrip(tmp_path: Path) -> None:
                 )
                 assert page.locator(
                     "#calculated_variables_md"
-                ).input_value().strip() == ("v = 7.5\nanswer = 7.5")
+                ).inner_text().strip() == ("v = 7.5\nanswer = 7.5")
                 assert (
                     page.locator("#mc_options_guidance").input_value()
                     == "Avoid sign-error distractors."
@@ -153,7 +153,7 @@ def test_browser_question_roundtrip(tmp_path: Path) -> None:
                 assert page.locator("#answer_formula_md").input_value().strip() == (
                     "v = float(v)\nanswer = v"
                 )
-                assert page.locator("#rendered_answer_md").input_value() == (
+                assert page.locator("#rendered_answer_md").inner_text() == (
                     "Use kinematics: 7.5 m/s."
                 )
                 assert page.locator("#points").input_value() == "8"
@@ -163,7 +163,7 @@ def test_browser_question_roundtrip(tmp_path: Path) -> None:
                 )
                 assert page.locator(
                     "#calculated_variables_md"
-                ).input_value().strip() == ("v = 7.5\nanswer = 7.5")
+                ).inner_text().strip() == ("v = 7.5\nanswer = 7.5")
                 assert (
                     page.locator("#mc_options_guidance").input_value()
                     == "Avoid sign-error distractors."

--- a/tests/integration/test_browser_question_roundtrip.py
+++ b/tests/integration/test_browser_question_roundtrip.py
@@ -75,7 +75,7 @@ def test_browser_question_roundtrip(tmp_path: Path) -> None:
                 "question_type": "free_response",
                 "question_template_md": "A block moves with speed {{v}} m/s.",
                 "solution_parameters_yaml": "v: 7.5",
-                "answer_formula_md": "v = float(params.get('v', 0))\nanswer = v",
+                "answer_formula_md": "v = float(v)\nanswer = v",
                 "answer_guidance": "Use kinematics: {{v}} m/s.",
                 "mc_options_guidance": "Avoid sign-error distractors.",
                 "distractor_functions_text": "",
@@ -112,9 +112,9 @@ def test_browser_question_roundtrip(tmp_path: Path) -> None:
                     == "v: 7.5"
                 )
                 assert page.locator("#answer_formula_md").input_value().strip() == (
-                    "v = float(params.get('v', 0))\nanswer = v"
+                    "v = float(v)\nanswer = v"
                 )
-                assert page.locator("#typed_solution_md").input_value() == (
+                assert page.locator("#rendered_answer_md").input_value() == (
                     "Use kinematics: 7.5 m/s."
                 )
                 assert page.locator("#points").input_value() == "8"
@@ -151,11 +151,10 @@ def test_browser_question_roundtrip(tmp_path: Path) -> None:
                     == "v: 7.5"
                 )
                 assert page.locator("#answer_formula_md").input_value().strip() == (
-                    "v = float(params.get('v', 0))\nanswer = v"
+                    "v = float(v)\nanswer = v"
                 )
-                assert (
-                    page.locator("#typed_solution_md").input_value()
-                    == "Use kinematics: 7.5 m/s."
+                assert page.locator("#rendered_answer_md").input_value() == (
+                    "Use kinematics: 7.5 m/s."
                 )
                 assert page.locator("#points").input_value() == "8"
                 assert (

--- a/tests/unit/test_ai_service.py
+++ b/tests/unit/test_ai_service.py
@@ -110,14 +110,14 @@ def test_ai_service_rewrite_parameterize_normalizes_fraction_and_drops_figure_re
     assert "fig_1" in out.question_template_md
 
 
-def test_ai_service_generate_answer_function(monkeypatch) -> None:
+def test_ai_service_generate_answer_formula(monkeypatch) -> None:
     from exam_helper import ai_service as mod
 
     payload = """{"answer_formula_md":"x = 1\\nanswer = x"}"""
     monkeypatch.setattr(mod, "OpenAI", lambda api_key: _FakeClient(payload))
     svc = AIService(api_key="k")
     q = Question(id="q1", title="t", prompt_md="old")
-    out = svc.generate_answer_function(q)
+    out = svc.generate_answer_formula(q)
     assert "answer = x" in out.answer_formula_md
 
 

--- a/tests/unit/test_ai_service.py
+++ b/tests/unit/test_ai_service.py
@@ -113,12 +113,12 @@ def test_ai_service_rewrite_parameterize_normalizes_fraction_and_drops_figure_re
 def test_ai_service_generate_answer_function(monkeypatch) -> None:
     from exam_helper import ai_service as mod
 
-    payload = """{"answer_python_code":"def solve(params):\\n    return {'answer_md':'x','final_answer':'x'}"}"""
+    payload = """{"answer_formula_md":"x = 1\\nanswer = x"}"""
     monkeypatch.setattr(mod, "OpenAI", lambda api_key: _FakeClient(payload))
     svc = AIService(api_key="k")
     q = Question(id="q1", title="t", prompt_md="old")
     out = svc.generate_answer_function(q)
-    assert "def solve(params)" in out.answer_python_code
+    assert "answer = x" in out.answer_formula_md
 
 
 def test_ai_service_generate_distractor_functions(monkeypatch) -> None:

--- a/tests/unit/test_prompt_catalog.py
+++ b/tests/unit/test_prompt_catalog.py
@@ -21,6 +21,16 @@ def test_prompt_catalog_builds_rewrite_prompt() -> None:
     assert "Current prompt" not in bundle.user_prompt
 
 
+def test_prompt_catalog_builds_answer_formula_prompt() -> None:
+    catalog = PromptCatalog.from_package_yaml()
+    q = Question(id="q1", title="T", prompt_md="P")
+    q.solution.answer_formula_md = "answer = 1"
+    q.solution.answer_guidance = "Use the final value."
+    bundle = catalog.compose(action="generate_answer_function", question=q)
+    assert "Answer Formula (SymPy):" in bundle.user_prompt
+    assert "Answer Text (Markdown):" in bundle.user_prompt
+
+
 def test_prompt_catalog_applies_overall_and_rewrite_override() -> None:
     catalog = PromptCatalog.from_package_yaml()
     q = Question(id="q1", title="T", prompt_md="P")
@@ -52,22 +62,18 @@ def test_prompt_catalog_applies_solution_and_mc_override_to_answer_generation() 
 def test_prompt_catalog_omits_empty_old_code_sections() -> None:
     catalog = PromptCatalog.from_package_yaml()
     q = Question(id="q1", title="T", prompt_md="P")
-    q.solution.answer_python_code = (
-        "def solve(params): return {'answer_md':'1','final_answer':'1'}"
-    )
+    q.solution.answer_formula_md = "answer = 1"
     q.solution.distractor_python_code = []
     bundle = catalog.compose(action="generate_distractor_functions", question=q)
     assert "Distractor Functions (Python):" not in bundle.user_prompt
     assert "MC Distractor Guidance (Markdown):" not in bundle.user_prompt
-    assert "Answer Function (Python):" in bundle.user_prompt
+    assert "Answer Formula (SymPy):" in bundle.user_prompt
 
 
 def test_prompt_catalog_includes_mc_distractor_guidance_when_present() -> None:
     catalog = PromptCatalog.from_package_yaml()
     q = Question(id="q1", title="T", prompt_md="P")
-    q.solution.answer_python_code = (
-        "def solve(params): return {'answer_md':'1','final_answer':'1'}"
-    )
+    q.solution.answer_formula_md = "answer = 1"
     q.mc_options_guidance = "Prefer unit-conversion mistakes over algebra mistakes."
     bundle = catalog.compose(action="generate_distractor_functions", question=q)
     assert "MC Distractor Guidance (Markdown):" in bundle.user_prompt

--- a/tests/unit/test_prompt_catalog.py
+++ b/tests/unit/test_prompt_catalog.py
@@ -26,7 +26,7 @@ def test_prompt_catalog_builds_answer_formula_prompt() -> None:
     q = Question(id="q1", title="T", prompt_md="P")
     q.solution.answer_formula_md = "answer = 1"
     q.solution.answer_guidance = "Use the final value."
-    bundle = catalog.compose(action="generate_answer_function", question=q)
+    bundle = catalog.compose(action="generate_answer_formula", question=q)
     assert "Answer Formula (SymPy):" in bundle.user_prompt
     assert "Answer Text (Markdown):" in bundle.user_prompt
 
@@ -50,7 +50,7 @@ def test_prompt_catalog_applies_solution_and_mc_override_to_answer_generation() 
     catalog = PromptCatalog.from_package_yaml()
     q = Question(id="q1", title="T", prompt_md="P")
     bundle = catalog.compose(
-        action="generate_answer_function",
+        action="generate_answer_formula",
         question=q,
         prompts_override=AIPromptConfig(
             solution_and_mc="Keep units explicit in final_answer."

--- a/tests/unit/test_solution_runtime.py
+++ b/tests/unit/test_solution_runtime.py
@@ -6,26 +6,37 @@ import pytest
 
 from exam_helper.solution_runtime import (
     SolutionRuntimeError,
-    run_answer_function,
+    run_answer_formula,
     run_distractor_function,
     run_mc_harness,
 )
 
 
-def test_answer_function_success() -> None:
-    code = (
-        "def solve(params):\n"
-        "    v = float(params.get('v', 1.0))\n"
-        "    return {'answer_md': f'v={v:.1f} m/s', 'final_answer': f'{v:.1f} m/s'}\n"
+def test_answer_formula_success() -> None:
+    code = "v = float(params.get('v', 1.0))\nanswer = v"
+    result = run_answer_formula(
+        code, {"v": 2.5}, answer_text_md="v={{v}} m/s", strict=True
     )
-    result = run_answer_function(code, {"v": 2.5})
+    assert result.calculated_variables_md == "v = 2.5\nanswer = 2.5"
     assert result.answer_md == "v=2.5 m/s"
-    assert result.final_answer == "2.5 m/s"
+    assert result.final_answer == "2.5"
 
 
-def test_answer_function_requires_solve() -> None:
-    with pytest.raises(SolutionRuntimeError, match="must define callable solve"):
-        run_answer_function("x = 1", {})
+def test_answer_formula_requires_nonempty_formula() -> None:
+    with pytest.raises(SolutionRuntimeError, match="Formula text is empty"):
+        run_answer_formula("", {})
+
+
+def test_answer_formula_tracks_last_expression() -> None:
+    result = run_answer_formula("x = 1\nx + 2", {}, strict=True)
+    assert result.calculated_variables_md == "x = 1\nresult = 3\nanswer = 3"
+    assert result.final_answer == "3"
+
+
+def test_answer_formula_warns_when_answer_is_defined_directly() -> None:
+    result = run_answer_formula("answer = 5", {}, strict=True)
+    assert result.final_answer == "5"
+    assert result.warnings
 
 
 def test_distractor_function_success() -> None:
@@ -52,10 +63,7 @@ def test_distractor_function_repairs_swapped_answer_and_rationale() -> None:
 
 
 def test_harness_detects_collisions() -> None:
-    answer_code = (
-        "def solve(params):\n"
-        "    return {'answer_md': 'Answer is 2 m/s', 'final_answer': '2 m/s'}\n"
-    )
+    answer_code = "answer = '2 m/s'"
     distractor_code = (
         "def distractor(params):\n"
         "    return {'distractor_md': '2 m/s', 'rationale': 'duplicate'}\n"
@@ -74,10 +82,7 @@ def test_harness_detects_collisions() -> None:
 
 
 def test_harness_sorts_numeric_then_text_tiebreak_by_source() -> None:
-    answer_code = (
-        "def solve(params):\n"
-        "    return {'answer_md': 'Ans', 'final_answer': '10 m/s'}\n"
-    )
+    answer_code = "answer = '10 m/s'"
     d1 = "def distractor(params):\n    return {'distractor_md': '2 m/s', 'rationale': 'r'}\n"
     d2 = "def distractor(params):\n    return {'distractor_md': '20 m/s', 'rationale': 'r'}\n"
     d3 = "def distractor(params):\n    return {'distractor_md': 'alpha', 'rationale': 'r'}\n"
@@ -95,24 +100,17 @@ def test_harness_sorts_numeric_then_text_tiebreak_by_source() -> None:
     ]
 
 
-def test_answer_function_latex_sequences_do_not_emit_invalid_escape_warnings() -> None:
-    code = (
-        "def solve(params):\n"
-        "    return {'answer_md': '$\\theta$', 'final_answer': '$\\lambda$'}\n"
-    )
+def test_answer_formula_latex_sequences_do_not_emit_invalid_escape_warnings() -> None:
+    code = "answer = 1"
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
-        result = run_answer_function(code, {})
+        result = run_answer_formula(code, {}, answer_text_md=r"$\theta$")
     assert result.answer_md == r"$\theta$"
-    assert result.final_answer == r"$\lambda$"
+    assert result.final_answer == "1"
     assert not [w for w in caught if "invalid escape sequence" in str(w.message)]
 
 
-def test_answer_function_preserves_existing_double_escaped_latex() -> None:
-    code = (
-        "def solve(params):\n"
-        "    return {'answer_md': '$\\\\theta$', 'final_answer': '$\\\\lambda$'}\n"
-    )
-    out = run_answer_function(code, {})
-    assert out.answer_md == r"$\theta$"
-    assert out.final_answer == r"$\lambda$"
+def test_answer_formula_preserves_existing_double_escaped_latex() -> None:
+    out = run_answer_formula("answer = 1", {}, answer_text_md=r"$\\theta$")
+    assert out.answer_md == r"$\\theta$"
+    assert out.final_answer == "1"

--- a/tests/unit/test_solution_runtime.py
+++ b/tests/unit/test_solution_runtime.py
@@ -170,6 +170,30 @@ def test_mc_formula_harness_allows_distractors_to_use_answer_locals() -> None:
     assert [c.content_md for c in out.choices] == ["3", "4", "5", "6", "7"]
 
 
+def test_mc_formula_harness_bare_distractor_expression_overrides_seed_answer() -> None:
+    out = run_mc_formula_harness(
+        "answer = 55",
+        [
+            {"formula_md": "33", "rationale_md": "constant distractor"},
+        ],
+        {},
+        strict=True,
+    )
+    assert out.row_previews[1]["content_md"] == "33"
+    assert [c.content_md for c in out.choices] == ["33", "55"]
+
+
+def test_evaluate_answer_formula_bare_expression_overrides_inherited_answer() -> None:
+    locals_ns, rendered_lines, warnings, fatal_error = evaluate_answer_formula(
+        "33",
+        {"answer": 55, "base": 2},
+    )
+    assert fatal_error is None
+    assert warnings == []
+    assert locals_ns["answer"] == 33
+    assert rendered_lines == ["answer = 33"]
+
+
 def test_answer_formula_latex_sequences_do_not_emit_invalid_escape_warnings() -> None:
     code = "answer = 1"
     with warnings.catch_warnings(record=True) as caught:

--- a/tests/unit/test_solution_runtime.py
+++ b/tests/unit/test_solution_runtime.py
@@ -154,6 +154,22 @@ def test_mc_formula_harness_uses_answer_formula_for_the_correct_choice() -> None
     assert out.row_previews[1]["content_md"] == "3"
 
 
+def test_mc_formula_harness_allows_distractors_to_use_answer_locals() -> None:
+    out = run_mc_formula_harness(
+        "base = 2\nanswer = base + scale",
+        [
+            {"formula_md": "answer = base + 1", "rationale_md": "uses answer locals"},
+            {"formula_md": "answer = base + 2", "rationale_md": "uses answer locals"},
+            {"formula_md": "answer = base + 3", "rationale_md": "uses answer locals"},
+            {"formula_md": "answer = base + 4", "rationale_md": "uses answer locals"},
+        ],
+        {"scale": 5},
+        strict=True,
+    )
+    assert out.correct_answer_md == "7"
+    assert [c.content_md for c in out.choices] == ["3", "4", "5", "6", "7"]
+
+
 def test_answer_formula_latex_sequences_do_not_emit_invalid_escape_warnings() -> None:
     code = "answer = 1"
     with warnings.catch_warnings(record=True) as caught:

--- a/tests/unit/test_solution_runtime.py
+++ b/tests/unit/test_solution_runtime.py
@@ -15,7 +15,7 @@ from exam_helper.solution_runtime import (
 
 def test_evaluate_answer_formula_returns_raw_evaluation_state() -> None:
     locals_ns, rendered_lines, warnings, fatal_error = evaluate_answer_formula(
-        "x = params['v']\ny = x + 2\nanswer = y", {"v": 5}
+        "x = v\ny = x + 2\nanswer = y", {"v": 5}
     )
     assert locals_ns["x"] == 5
     assert locals_ns["y"] == 7
@@ -30,13 +30,14 @@ def test_evaluate_answer_formula_reports_fatal_errors() -> None:
         "x = 1\nanswer = missing_name", {}
     )
     assert locals_ns["x"] == 1
-    assert rendered_lines == ["x = 1", "answer = 1"]
+    assert "answer" not in locals_ns
+    assert rendered_lines == ["x = 1"]
     assert warnings
     assert fatal_error is not None
 
 
 def test_answer_formula_success() -> None:
-    code = "v = float(params.get('v', 1.0))\nanswer = v"
+    code = "v = float(v)\nanswer = v"
     result = run_answer_formula(
         code, {"v": 2.5}, answer_text_md="v={{v}} m/s", strict=True
     )
@@ -52,8 +53,19 @@ def test_answer_formula_requires_nonempty_formula() -> None:
 
 def test_answer_formula_tracks_last_expression() -> None:
     result = run_answer_formula("x = 1\nx + 2", {}, strict=True)
-    assert result.calculated_variables_md == "x = 1\nresult = 3\nanswer = 3"
+    assert result.calculated_variables_md == "x = 1\nanswer = 3"
     assert result.final_answer == "3"
+
+
+def test_answer_formula_does_not_backfill_answer_after_a_fatal_error() -> None:
+    locals_ns, rendered_lines, warnings, fatal_error = evaluate_answer_formula(
+        "x = 1\nanswer = missing_name", {}
+    )
+    assert locals_ns["x"] == 1
+    assert "answer" not in locals_ns
+    assert rendered_lines == ["x = 1"]
+    assert warnings
+    assert fatal_error is not None
 
 
 def test_answer_formula_warns_when_answer_is_defined_directly() -> None:

--- a/tests/unit/test_solution_runtime.py
+++ b/tests/unit/test_solution_runtime.py
@@ -6,10 +6,33 @@ import pytest
 
 from exam_helper.solution_runtime import (
     SolutionRuntimeError,
+    evaluate_answer_formula,
     run_answer_formula,
     run_distractor_function,
     run_mc_harness,
 )
+
+
+def test_evaluate_answer_formula_returns_raw_evaluation_state() -> None:
+    locals_ns, rendered_lines, warnings, fatal_error = evaluate_answer_formula(
+        "x = params['v']\ny = x + 2\nanswer = y", {"v": 5}
+    )
+    assert locals_ns["x"] == 5
+    assert locals_ns["y"] == 7
+    assert locals_ns["answer"] == 7
+    assert rendered_lines == ["x = 5", "y = 7", "answer = 7"]
+    assert warnings == ["Formula defines answer directly; it will not be overwritten."]
+    assert fatal_error is None
+
+
+def test_evaluate_answer_formula_reports_fatal_errors() -> None:
+    locals_ns, rendered_lines, warnings, fatal_error = evaluate_answer_formula(
+        "x = 1\nanswer = missing_name", {}
+    )
+    assert locals_ns["x"] == 1
+    assert rendered_lines == ["x = 1", "answer = 1"]
+    assert warnings
+    assert fatal_error is not None
 
 
 def test_answer_formula_success() -> None:

--- a/tests/unit/test_solution_runtime.py
+++ b/tests/unit/test_solution_runtime.py
@@ -8,6 +8,7 @@ from exam_helper.solution_runtime import (
     SolutionRuntimeError,
     evaluate_answer_formula,
     run_answer_formula,
+    run_mc_formula_harness,
     run_distractor_function,
     run_mc_harness,
 )
@@ -133,6 +134,24 @@ def test_harness_sorts_numeric_then_text_tiebreak_by_source() -> None:
         "alpha",
         "beta",
     ]
+
+
+def test_mc_formula_harness_uses_answer_formula_for_the_correct_choice() -> None:
+    out = run_mc_formula_harness(
+        "answer = 2",
+        [
+            {"formula_md": "answer = 3", "rationale_md": "off by one"},
+            {"formula_md": "answer = 4", "rationale_md": "off by two"},
+            {"formula_md": "answer = 5", "rationale_md": "off by three"},
+            {"formula_md": "answer = 6", "rationale_md": "off by four"},
+        ],
+        {},
+        strict=True,
+    )
+    assert out.correct_answer_md == "2"
+    assert [c.content_md for c in out.choices] == ["2", "3", "4", "5", "6"]
+    assert out.row_previews[0]["content_md"] == "2"
+    assert out.row_previews[1]["content_md"] == "3"
 
 
 def test_answer_formula_latex_sequences_do_not_emit_invalid_escape_warnings() -> None:

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -17,10 +17,7 @@ def test_validate_project_with_solution_code(tmp_path: Path) -> None:
         title="t",
         prompt_md="p",
         solution={
-            "python_code": (
-                "def solve(params, context):\n"
-                "    return {'final_answer_text': 'ok'}\n"
-            ),
+            "answer_formula_md": "answer = 'ok'",
             "parameters": {},
         },
     )
@@ -60,9 +57,7 @@ def test_validate_project_skips_soft_deleted_questions(tmp_path: Path) -> None:
             title="t",
             is_deleted=True,
             solution={
-                "answer_python_code": (
-                    "def solve(params, context):\n" "    raise RuntimeError('boom')\n"
-                ),
+                "answer_formula_md": "raise RuntimeError('boom')",
                 "parameters": {},
             },
         )


### PR DESCRIPTION
## What changed
- Reworked answer-formula evaluation to use SymPy-aware expression parsing instead of `eval` / `exec`.
- Stopped overwriting the worked-solution field with the computed markdown answer; the editor now keeps the preview in `last_computed_answer_md`.
- Renamed the answer-generation API and prompt action from `answer function` to `answer formula`.
- Updated the question editor UI to show the computed markdown answer as a separate read-only preview.

## Why
- This branch closes out the issue to replace Python answer functions with multiline SymPy formulas and to keep the editor storage split clean.

## Validation
- `uv run --extra dev pytest -q`
- `uv run --extra dev black --check src tests`

Fixes #62 .