### PR TITLE
Add AI chat editor to question form

### DIFF
--- a/src/exam_helper/ai_service.py
+++ b/src/exam_helper/ai_service.py
@@ -88,6 +88,18 @@ class AIService:
             ]
             return self
 
+    class ChatFinishArgs(BaseModel):
+        assistant_message: str
+        warnings: list[str] = Field(default_factory=list)
+
+        @model_validator(mode="after")
+        def _normalize(self) -> "AIService.ChatFinishArgs":
+            self.assistant_message = self.assistant_message.strip()
+            self.warnings = [
+                str(item).strip() for item in self.warnings if str(item).strip()
+            ]
+            return self
+
     @dataclass
     class QuestionEditorResult:
         assistant_message: str
@@ -354,6 +366,26 @@ class AIService:
     @staticmethod
     def _tool_schema() -> list[dict[str, Any]]:
         return [
+            {
+                "type": "function",
+                "name": "finish",
+                "description": (
+                    "Finish the editing task and return the final assistant message. "
+                    "Call this exactly once when you are done."
+                ),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "assistant_message": {"type": "string"},
+                        "warnings": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
+                    },
+                    "required": ["assistant_message"],
+                    "additionalProperties": False,
+                },
+            },
             {
                 "type": "function",
                 "name": "get_exam_item",
@@ -625,9 +657,10 @@ class AIService:
             "You are editing a single exam item for a physics-authoring app. "
             "Use the provided tools to inspect and update the item. "
             "Do not invent fields or return raw patches. "
-            "Use deterministic tools for answer and distractor code changes. "
-            "After you are done, return one JSON object only with keys assistant_message and warnings. "
-            "Keep the assistant_message short and factual."
+            "Use deterministic tools for answer and distractor changes. "
+            "For rewrite or parameter-extraction requests, call only the minimal tools needed. "
+            "Do not call compute_answer unless the author explicitly asks you to calculate, compute, or solve. "
+            "When you are done, call the finish tool exactly once with a short factual assistant_message."
         )
         user_content: list[dict[str, Any]] = [
             {
@@ -666,7 +699,7 @@ class AIService:
         loop_guard = 0
         while True:
             loop_guard += 1
-            if loop_guard > 12:
+            if loop_guard > 20:
                 raise ValueError("AI chat exceeded the tool-call limit.")
             tool_calls = self._response_tool_calls(response)
             if not tool_calls:
@@ -682,6 +715,19 @@ class AIService:
                 )
             outputs: list[dict[str, Any]] = []
             for call in tool_calls:
+                if str(getattr(call, "name", "")) == "finish":
+                    payload = self._parse_json_object(
+                        str(getattr(call, "arguments", "") or "{}")
+                    )
+                    parsed = AIService.ChatFinishArgs.model_validate(payload)
+                    final_warnings = warnings + parsed.warnings
+                    return AIService.QuestionEditorResult(
+                        assistant_message=parsed.assistant_message,
+                        question=working,
+                        warnings=final_warnings,
+                        usage=self._combine_usage(usage_parts),
+                        changed_fields=sorted(changed_fields),
+                    )
                 try:
                     result = self._execute_chat_tool(
                         working,

--- a/src/exam_helper/ai_service.py
+++ b/src/exam_helper/ai_service.py
@@ -230,11 +230,6 @@ class AIService:
                 chunks.append(f"# distractor: {f.id}\n{(f.python_code or '').strip()}")
             return "\n---\n".join(chunks).strip() + "\n"
 
-        def _dump_mc_answer_specs(specs: list) -> str:
-            return json.dumps(
-                [spec.model_dump(mode="json") for spec in specs], ensure_ascii=False
-            )
-
         def _dump_mc_answer_specs(specs: list[MCAnswerSpec]) -> str:
             return json.dumps(
                 [spec.model_dump(mode="json") for spec in specs], ensure_ascii=False

--- a/src/exam_helper/ai_service.py
+++ b/src/exam_helper/ai_service.py
@@ -8,14 +8,25 @@ from typing import Any
 
 from openai import OpenAI
 import yaml
+from pydantic import BaseModel, Field, model_validator
 
 from exam_helper.models import (
     AIPromptConfig,
     AIUsageTotals,
+    ChatTurn,
     DistractorFunction,
+    MCAnswerSpec,
     Question,
+    QuestionType,
 )
 from exam_helper.prompt_catalog import PromptBundle, PromptCatalog
+from exam_helper.solution_runtime import (
+    SolutionRuntimeError,
+    run_answer_formula,
+    run_mc_formula_harness,
+    run_mc_harness,
+)
+from exam_helper.validation import validate_question
 
 logger = logging.getLogger(__name__)
 
@@ -48,6 +59,42 @@ class AIService:
     class DistractorFunctionsResult:
         distractors: list[DistractorFunction]
         usage: AIUsageTotals
+
+    class QuestionEditorState(BaseModel):
+        title: str = ""
+        question_type: str = "free_response"
+        points: int = 5
+        mc_options_guidance: str = ""
+        question_template_md: str = ""
+        solution_parameters_yaml: str = "{}"
+        answer_formula_md: str = ""
+        answer_guidance: str = ""
+        distractor_functions_text: str = ""
+        mc_answer_specs_json: str = "[]"
+        choices_yaml: str = "[]"
+        typed_solution_md: str = ""
+        typed_solution_status: str = "missing"
+        last_computed_answer_md: str = ""
+
+    class ChatAssistantResponse(BaseModel):
+        assistant_message: str
+        warnings: list[str] = Field(default_factory=list)
+
+        @model_validator(mode="after")
+        def _normalize(self) -> "AIService.ChatAssistantResponse":
+            self.assistant_message = self.assistant_message.strip()
+            self.warnings = [
+                str(item).strip() for item in self.warnings if str(item).strip()
+            ]
+            return self
+
+    @dataclass
+    class QuestionEditorResult:
+        assistant_message: str
+        question: Question
+        warnings: list[str]
+        usage: AIUsageTotals
+        changed_fields: list[str]
 
     def _client(self) -> OpenAI:
         if not self.api_key:
@@ -149,9 +196,14 @@ class AIService:
         return max(0.0, input_cost + output_cost)
 
     @staticmethod
-    def _figure_content(question: Question) -> list[dict]:
+    def _figure_content(
+        question: Question, figure_ids: list[str] | None = None
+    ) -> list[dict]:
         items: list[dict] = []
+        selected = set(figure_ids or [])
         for fig in question.figures:
+            if selected and fig.id not in selected:
+                continue
             caption = fig.caption or fig.id
             items.append({"type": "input_text", "text": f"Figure {fig.id}: {caption}"})
             items.append(
@@ -162,6 +214,59 @@ class AIService:
                 }
             )
         return items
+
+    @staticmethod
+    def _editor_state_for_question(
+        question: Question,
+    ) -> "AIService.QuestionEditorState":
+        def _dump_parameters(params: dict[str, Any]) -> str:
+            return yaml.safe_dump(params or {}, sort_keys=False).strip()
+
+        def _dump_distractors(funcs: list[DistractorFunction]) -> str:
+            if not funcs:
+                return ""
+            chunks: list[str] = []
+            for f in funcs:
+                chunks.append(f"# distractor: {f.id}\n{(f.python_code or '').strip()}")
+            return "\n---\n".join(chunks).strip() + "\n"
+
+        def _dump_mc_answer_specs(specs: list) -> str:
+            return json.dumps(
+                [spec.model_dump(mode="json") for spec in specs], ensure_ascii=False
+            )
+
+        def _dump_mc_answer_specs(specs: list[MCAnswerSpec]) -> str:
+            return json.dumps(
+                [spec.model_dump(mode="json") for spec in specs], ensure_ascii=False
+            )
+
+        def _dump_choices(choices: list) -> str:
+            payload = [
+                c.model_dump(mode="json", exclude_none=True)
+                for c in sorted(choices, key=lambda x: x.label)
+            ]
+            return yaml.safe_dump(payload, sort_keys=False)
+
+        return AIService.QuestionEditorState(
+            title=question.title,
+            question_type=question.question_type.value,
+            points=question.points,
+            mc_options_guidance=question.mc_options_guidance,
+            question_template_md=question.solution.question_template_md,
+            solution_parameters_yaml=_dump_parameters(question.solution.parameters),
+            answer_formula_md=question.solution.answer_formula_md,
+            answer_guidance=question.solution.answer_guidance,
+            distractor_functions_text=_dump_distractors(
+                question.solution.distractor_python_code
+            ),
+            mc_answer_specs_json=_dump_mc_answer_specs(
+                question.solution.mc_answer_specs
+            ),
+            choices_yaml=_dump_choices(question.choices),
+            typed_solution_md=question.solution.typed_solution_md,
+            typed_solution_status=question.solution.typed_solution_status,
+            last_computed_answer_md=question.solution.last_computed_answer_md,
+        )
 
     def _text_with_question_context(
         self, bundle: PromptBundle, question: Question
@@ -180,6 +285,432 @@ class AIService:
         if not text:
             raise ValueError("Empty AI response.")
         return AIService.AIResult(text=text, usage=self._usage_from_response(response))
+
+    @staticmethod
+    def _truncate_chat_history(turns: list[ChatTurn], keep: int = 5) -> list[ChatTurn]:
+        if keep <= 0:
+            return []
+        return [turn.model_copy(deep=True) for turn in turns[-keep:]]
+
+    @staticmethod
+    def _response_tool_calls(response: Any) -> list[Any]:
+        output = getattr(response, "output", None) or []
+        return [
+            item
+            for item in output
+            if getattr(item, "type", None) == "function_call"
+            and getattr(item, "name", None)
+        ]
+
+    @classmethod
+    def _combine_usage(cls, totals: list[AIUsageTotals]) -> AIUsageTotals:
+        usage = AIUsageTotals()
+        for item in totals:
+            usage.input_tokens += int(item.input_tokens or 0)
+            usage.output_tokens += int(item.output_tokens or 0)
+            usage.total_tokens += int(item.total_tokens or 0)
+            usage.total_cost_usd += float(item.total_cost_usd or 0.0)
+        return usage
+
+    @staticmethod
+    def _dump_choices_yaml(choices: list[Any]) -> str:
+        payload = [
+            c.model_dump(mode="json", exclude_none=True)
+            for c in sorted(choices, key=lambda x: x.label)
+        ]
+        return yaml.safe_dump(payload, sort_keys=False)
+
+    @classmethod
+    def _sync_mc_choices(
+        cls, question: Question, changed_fields: set[str], warnings: list[str]
+    ) -> None:
+        if question.question_type != QuestionType.multiple_choice:
+            return
+        if not question.solution.answer_formula_md.strip():
+            return
+        try:
+            if question.solution.mc_answer_specs:
+                harness = run_mc_formula_harness(
+                    answer_formula_md=question.solution.answer_formula_md,
+                    mc_answer_specs=question.solution.mc_answer_specs,
+                    params=question.solution.parameters,
+                    strict=False,
+                )
+            else:
+                funcs = question.solution.distractor_python_code
+                if len(funcs) != 4 or any(not d.python_code.strip() for d in funcs):
+                    return
+                harness = run_mc_harness(
+                    answer_formula_md=question.solution.answer_formula_md,
+                    distractor_python_codes=[(d.id, d.python_code) for d in funcs],
+                    params=question.solution.parameters,
+                )
+        except SolutionRuntimeError as ex:
+            warnings.append(str(ex))
+            return
+        except Exception as ex:
+            warnings.append(str(ex))
+            return
+        question.choices = harness.choices
+        changed_fields.add("choices_yaml")
+        if harness.collisions:
+            warnings.extend(harness.collisions)
+
+    @staticmethod
+    def _tool_schema() -> list[dict[str, Any]]:
+        return [
+            {
+                "type": "function",
+                "name": "get_exam_item",
+                "description": "Get the current editable exam item state.",
+                "parameters": {"type": "object", "properties": {}},
+            },
+            {
+                "type": "function",
+                "name": "set_title",
+                "description": "Set the short question title.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"title": {"type": "string"}},
+                    "required": ["title"],
+                    "additionalProperties": False,
+                },
+            },
+            {
+                "type": "function",
+                "name": "set_question_type",
+                "description": "Set the question type.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "question_type": {
+                            "type": "string",
+                            "enum": ["free_response", "multiple_choice"],
+                        }
+                    },
+                    "required": ["question_type"],
+                    "additionalProperties": False,
+                },
+            },
+            {
+                "type": "function",
+                "name": "set_points",
+                "description": "Set the point value for the item.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"points": {"type": "integer"}},
+                    "required": ["points"],
+                    "additionalProperties": False,
+                },
+            },
+            {
+                "type": "function",
+                "name": "set_question_text",
+                "description": "Replace the question markdown/template text.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"question_template_md": {"type": "string"}},
+                    "required": ["question_template_md"],
+                    "additionalProperties": False,
+                },
+            },
+            {
+                "type": "function",
+                "name": "set_parameters",
+                "description": "Replace the YAML/JSON parameters mapping.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"parameters": {}},
+                    "required": ["parameters"],
+                    "additionalProperties": False,
+                },
+            },
+            {
+                "type": "function",
+                "name": "set_answer_guidance",
+                "description": "Set private guidance for the deterministic solution code.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"answer_guidance": {"type": "string"}},
+                    "required": ["answer_guidance"],
+                    "additionalProperties": False,
+                },
+            },
+            {
+                "type": "function",
+                "name": "set_answer_formula",
+                "description": "Replace the answer formula text and validate it.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"answer_formula_md": {"type": "string"}},
+                    "required": ["answer_formula_md"],
+                    "additionalProperties": False,
+                },
+            },
+            {
+                "type": "function",
+                "name": "compute_answer",
+                "description": "Run the current deterministic answer formula and store the rendered answer.",
+                "parameters": {"type": "object", "properties": {}},
+            },
+            {
+                "type": "function",
+                "name": "set_distractor",
+                "description": "Set one multiple-choice distractor by 1-based index using formula and rationale text.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "index": {"type": "integer"},
+                        "formula_md": {"type": "string"},
+                        "rationale_md": {"type": "string"},
+                    },
+                    "required": ["index", "formula_md"],
+                    "additionalProperties": False,
+                },
+            },
+            {
+                "type": "function",
+                "name": "delete_distractor",
+                "description": "Delete one distractor function by 1-based index.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"index": {"type": "integer"}},
+                    "required": ["index"],
+                    "additionalProperties": False,
+                },
+            },
+            {
+                "type": "function",
+                "name": "set_mc_options_guidance",
+                "description": "Set the multiple-choice author guidance text.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"mc_options_guidance": {"type": "string"}},
+                    "required": ["mc_options_guidance"],
+                    "additionalProperties": False,
+                },
+            },
+            {
+                "type": "function",
+                "name": "validate_exam_item",
+                "description": "Run validation against the current exam item and return any problems.",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        ]
+
+    def _execute_chat_tool(
+        self,
+        question: Question,
+        tool_name: str,
+        raw_arguments: str,
+        changed_fields: set[str],
+        warnings: list[str],
+    ) -> dict[str, Any]:
+        args = self._parse_json_object(raw_arguments or "{}")
+        if tool_name == "get_exam_item":
+            state = self._editor_state_for_question(question).model_dump(mode="json")
+            state["figure_ids"] = [fig.id for fig in question.figures]
+            return {"ok": True, "state": state}
+        if tool_name == "set_title":
+            question.title = str(args.get("title", ""))
+            changed_fields.add("title")
+            return {"ok": True}
+        if tool_name == "set_question_type":
+            question.question_type = QuestionType(str(args.get("question_type")))
+            changed_fields.add("question_type")
+            self._sync_mc_choices(question, changed_fields, warnings)
+            return {"ok": True, "question_type": question.question_type.value}
+        if tool_name == "set_points":
+            question.points = int(args.get("points", question.points))
+            changed_fields.add("points")
+            return {"ok": True, "points": question.points}
+        if tool_name == "set_question_text":
+            question.solution.question_template_md = str(
+                args.get("question_template_md", "")
+            )
+            changed_fields.add("question_template_md")
+            return {"ok": True}
+        if tool_name == "set_parameters":
+            params = self._coerce_parameters_object(args.get("parameters"))
+            question.solution.parameters = params
+            changed_fields.add("solution_parameters_yaml")
+            self._sync_mc_choices(question, changed_fields, warnings)
+            return {"ok": True, "parameters": params}
+        if tool_name == "set_answer_guidance":
+            question.solution.answer_guidance = str(args.get("answer_guidance", ""))
+            changed_fields.add("answer_guidance")
+            return {"ok": True}
+        if tool_name == "set_answer_formula":
+            formula = str(args.get("answer_formula_md", "")).strip()
+            run_answer_formula(
+                formula,
+                question.solution.parameters,
+                answer_text_md=question.solution.answer_guidance,
+                strict=True,
+            )
+            question.solution.answer_formula_md = formula
+            changed_fields.add("answer_formula_md")
+            self._sync_mc_choices(question, changed_fields, warnings)
+            return {"ok": True}
+        if tool_name == "compute_answer":
+            result = run_answer_formula(
+                question.solution.answer_formula_md,
+                question.solution.parameters,
+                answer_text_md=question.solution.answer_guidance,
+                strict=True,
+            )
+            question.solution.last_computed_answer_md = result.answer_md
+            changed_fields.add("last_computed_answer_md")
+            return {
+                "ok": True,
+                "calculated_variables_md": result.calculated_variables_md,
+                "answer_md": result.answer_md,
+                "final_answer": result.final_answer,
+            }
+        if tool_name == "set_distractor":
+            index = int(args.get("index", 0))
+            if index < 1:
+                raise ValueError("Distractor index must be 1 or greater.")
+            specs = list(question.solution.mc_answer_specs)
+            while len(specs) < index:
+                specs.append(MCAnswerSpec())
+            specs[index - 1] = MCAnswerSpec(
+                formula_md=str(args.get("formula_md", "")).strip(),
+                rationale_md=str(args.get("rationale_md", "")).strip(),
+            )
+            question.solution.mc_answer_specs = specs
+            changed_fields.add("mc_answer_specs_json")
+            self._sync_mc_choices(question, changed_fields, warnings)
+            return {"ok": True, "index": index}
+        if tool_name == "delete_distractor":
+            index = int(args.get("index", 0))
+            if index < 1:
+                raise ValueError("Distractor index must be 1 or greater.")
+            specs = list(question.solution.mc_answer_specs)
+            if index > len(specs):
+                return {"ok": True, "deleted": False}
+            del specs[index - 1]
+            question.solution.mc_answer_specs = specs
+            question.choices = []
+            changed_fields.update({"mc_answer_specs_json", "choices_yaml"})
+            return {"ok": True, "deleted": True}
+        if tool_name == "set_mc_options_guidance":
+            question.mc_options_guidance = str(args.get("mc_options_guidance", ""))
+            changed_fields.add("mc_options_guidance")
+            return {"ok": True}
+        if tool_name == "validate_exam_item":
+            errors = validate_question(question)
+            return {"ok": not bool(errors), "errors": errors}
+        raise ValueError(f"Unsupported tool call: {tool_name}")
+
+    def chat_edit_question(
+        self,
+        question: Question,
+        user_message: str,
+        attached_figure_ids: list[str] | None = None,
+    ) -> QuestionEditorResult:
+        client = self._client()
+        working = question.model_copy(deep=True)
+        changed_fields: set[str] = set()
+        warnings: list[str] = []
+        recent_history = self._truncate_chat_history(working.solution.chat_history)
+        state = self._editor_state_for_question(working)
+        state_json = json.dumps(
+            state.model_dump(mode="json"), ensure_ascii=False, indent=2
+        )
+        history_lines = []
+        for turn in recent_history:
+            history_lines.append(f"User: {turn.user_message}")
+            history_lines.append(f"Assistant: {turn.assistant_message}")
+        history_text = "\n".join(history_lines) if history_lines else "(none)"
+        attached_ids = [
+            str(fid).strip() for fid in (attached_figure_ids or []) if str(fid).strip()
+        ]
+        system_prompt = (
+            "You are editing a single exam item for a physics-authoring app. "
+            "Use the provided tools to inspect and update the item. "
+            "Do not invent fields or return raw patches. "
+            "Use deterministic tools for answer and distractor code changes. "
+            "After you are done, return one JSON object only with keys assistant_message and warnings. "
+            "Keep the assistant_message short and factual."
+        )
+        user_content: list[dict[str, Any]] = [
+            {
+                "type": "input_text",
+                "text": (
+                    "Current editor state:\n"
+                    f"{state_json}\n\n"
+                    "Persisted recent chat history:\n"
+                    f"{history_text}\n\n"
+                    f"Current author request:\n{user_message.strip()}\n\n"
+                    "Only images attached to this turn are included below."
+                ),
+            }
+        ]
+        if attached_ids:
+            user_content.append(
+                {
+                    "type": "input_text",
+                    "text": "Attached figure ids for this turn: "
+                    + ", ".join(attached_ids),
+                }
+            )
+            user_content.extend(self._figure_content(working, attached_ids))
+        response = client.responses.create(
+            model=self.model,
+            input=[
+                {
+                    "role": "system",
+                    "content": [{"type": "input_text", "text": system_prompt}],
+                },
+                {"role": "user", "content": user_content},
+            ],
+            tools=self._tool_schema(),
+        )
+        usage_parts = [self._usage_from_response(response)]
+        loop_guard = 0
+        while True:
+            loop_guard += 1
+            if loop_guard > 12:
+                raise ValueError("AI chat exceeded the tool-call limit.")
+            tool_calls = self._response_tool_calls(response)
+            if not tool_calls:
+                payload = self._parse_json_object(getattr(response, "output_text", ""))
+                parsed = AIService.ChatAssistantResponse.model_validate(payload)
+                final_warnings = warnings + parsed.warnings
+                return AIService.QuestionEditorResult(
+                    assistant_message=parsed.assistant_message,
+                    question=working,
+                    warnings=final_warnings,
+                    usage=self._combine_usage(usage_parts),
+                    changed_fields=sorted(changed_fields),
+                )
+            outputs: list[dict[str, Any]] = []
+            for call in tool_calls:
+                try:
+                    result = self._execute_chat_tool(
+                        working,
+                        str(getattr(call, "name", "")),
+                        str(getattr(call, "arguments", "") or "{}"),
+                        changed_fields,
+                        warnings,
+                    )
+                except Exception as ex:
+                    result = {"ok": False, "error": str(ex)}
+                outputs.append(
+                    {
+                        "type": "function_call_output",
+                        "call_id": getattr(call, "call_id", ""),
+                        "output": json.dumps(result, ensure_ascii=False),
+                    }
+                )
+            response = client.responses.create(
+                model=self.model,
+                previous_response_id=getattr(response, "id", None),
+                input=outputs,
+                tools=self._tool_schema(),
+            )
+            usage_parts.append(self._usage_from_response(response))
 
     @staticmethod
     def _parse_json_object(raw: str) -> dict[str, Any]:

--- a/src/exam_helper/app.py
+++ b/src/exam_helper/app.py
@@ -18,6 +18,7 @@ from exam_helper.ai_service import AIService
 from exam_helper.export_docx import render_project_docx_bytes
 from exam_helper.models import (
     AIUsageTotals,
+    ChatTurn,
     DistractorFunction,
     MCAnswerSpec,
     MCChoice,
@@ -51,7 +52,14 @@ class AutosavePayload(BaseModel):
     typed_solution_md: str = ""
     typed_solution_status: str = "missing"
     figures_json: str = "[]"
+    chat_history_json: str = "[]"
     points: int = 5
+
+
+class ChatPayload(BaseModel):
+    message: str = ""
+    attached_figure_ids: list[str] = []
+    editor_state: AutosavePayload
 
 
 def _sanitize_docx_filename_stem(project_name: str) -> str:
@@ -382,6 +390,12 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
             question.solution.distractor_python_code if question else []
         )
         answer_preview = _compute_answer_preview(question)
+        chat_history_json = json.dumps(
+            [
+                turn.model_dump(mode="json")
+                for turn in (question.solution.chat_history[-5:] if question else [])
+            ]
+        )
         return {
             "question": question,
             "figures_json": figures_json,
@@ -404,10 +418,193 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
                 if question and question.solution.last_computed_answer_md.strip()
                 else answer_preview["rendered_answer_md"]
             ),
+            "chat_history_json": chat_history_json,
+            "ai_enabled": bool(openai_key),
             "question_id_default": (
                 question.id if question else _suggest_next_question_id()
             ),
         }
+
+    def _parse_chat_history_json(raw: str) -> list[ChatTurn]:
+        loaded = json.loads(raw or "[]")
+        if not isinstance(loaded, list):
+            raise ValueError("chat_history_json must be a JSON list.")
+        return [ChatTurn.model_validate(item) for item in loaded][-5:]
+
+    def _build_question_from_editor_values(
+        question_id: str,
+        existing: Question | None,
+        values: dict[str, Any],
+    ) -> tuple[Question, dict[str, Any], dict[str, Any]]:
+        figures = json.loads(str(values.get("figures_json", "[]")) or "[]")
+        solution_parameters = parse_parameters_yaml(
+            str(values.get("solution_parameters_yaml", "{}"))
+        )
+        distractor_funcs = parse_distractor_functions_text(
+            str(values.get("distractor_functions_text", ""))
+        )
+        mc_answer_specs = parse_mc_answer_specs_json(
+            str(values.get("mc_answer_specs_json", "[]"))
+        )
+        chat_history = _parse_chat_history_json(
+            str(
+                values.get(
+                    "chat_history_json",
+                    json.dumps(
+                        [
+                            turn.model_dump(mode="json")
+                            for turn in (
+                                existing.solution.chat_history if existing else []
+                            )
+                        ]
+                    ),
+                )
+            )
+        )
+        question_type_value = str(
+            values.get(
+                "question_type",
+                existing.question_type.value if existing else "free_response",
+            )
+        )
+        mc_preview = _compute_mc_preview(
+            str(values.get("answer_formula_md", "")),
+            mc_answer_specs,
+            solution_parameters,
+        )
+        if (
+            question_type_value == QuestionType.multiple_choice.value
+            and mc_answer_specs
+        ):
+            choices = mc_preview["choices"]
+        else:
+            choices = parse_choices_yaml(str(values.get("choices_yaml", "[]")))
+        question = Question.model_validate(
+            {
+                "id": question_id,
+                "title": str(values.get("title", "")),
+                "points": int(values.get("points", 5) or 5),
+                "is_deleted": (existing.is_deleted if existing else False),
+                "question_type": QuestionType(question_type_value),
+                "mc_options_guidance": str(values.get("mc_options_guidance", "")),
+                "choices": choices,
+                "solution": {
+                    "question_template_md": normalize_markdown_math_delimiters(
+                        str(values.get("question_template_md", ""))
+                    ),
+                    "parameters": solution_parameters,
+                    "answer_formula_md": str(values.get("answer_formula_md", "")),
+                    "answer_guidance": str(values.get("answer_guidance", "")),
+                    "mc_answer_specs": mc_answer_specs,
+                    "distractor_python_code": distractor_funcs,
+                    "typed_solution_md": normalize_markdown_math_delimiters(
+                        str(
+                            values.get(
+                                "typed_solution_md",
+                                existing.solution.typed_solution_md if existing else "",
+                            )
+                        )
+                    ),
+                    "typed_solution_status": str(
+                        values.get("typed_solution_status", "missing")
+                    ),
+                    "last_computed_answer_md": (
+                        normalize_markdown_math_delimiters(
+                            existing.solution.last_computed_answer_md
+                        )
+                        if existing
+                        else ""
+                    ),
+                    "chat_history": chat_history,
+                },
+                "figures": figures,
+            }
+        )
+        preview = _compute_answer_preview(question)
+        if not preview["fatal_error"]:
+            question.solution.last_computed_answer_md = (
+                preview["rendered_answer_md"]
+                or question.solution.last_computed_answer_md
+            )
+        _mark_typed_solution_stale_if_needed(existing, question)
+        mc_preview = _compute_mc_preview(
+            question.solution.answer_formula_md,
+            question.solution.mc_answer_specs,
+            question.solution.parameters,
+        )
+        return question, preview, mc_preview
+
+    def _editor_values_from_question(question: Question | None) -> dict[str, Any]:
+        return {
+            "title": question.title if question else "",
+            "points": question.points if question else 5,
+            "question_type": (
+                question.question_type.value
+                if question
+                else QuestionType.free_response.value
+            ),
+            "mc_options_guidance": question.mc_options_guidance if question else "",
+            "question_template_md": (
+                question.solution.question_template_md if question else ""
+            ),
+            "solution_parameters_yaml": dump_parameters_yaml(
+                question.solution.parameters if question else {}
+            ),
+            "answer_formula_md": (
+                question.solution.answer_formula_md if question else ""
+            ),
+            "answer_guidance": question.solution.answer_guidance if question else "",
+            "distractor_functions_text": dump_distractor_functions_text(
+                question.solution.distractor_python_code if question else []
+            ),
+            "mc_answer_specs_json": dump_mc_answer_specs_json(
+                question.solution.mc_answer_specs
+                if question
+                else default_mc_answer_specs()
+            ),
+            "choices_yaml": (
+                dump_choices_yaml(question.choices)
+                if question and question.choices
+                else default_mc_choices_yaml()
+            ),
+            "typed_solution_md": (
+                question.solution.typed_solution_md if question else ""
+            ),
+            "typed_solution_status": (
+                question.solution.typed_solution_status if question else "missing"
+            ),
+            "figures_json": json.dumps(
+                [f.model_dump(mode="json") for f in question.figures]
+                if question
+                else []
+            ),
+            "chat_history_json": json.dumps(
+                [
+                    turn.model_dump(mode="json")
+                    for turn in (
+                        question.solution.chat_history[-5:] if question else []
+                    )
+                ]
+            ),
+        }
+
+    def _append_chat_turn(
+        question: Question,
+        *,
+        user_message: str,
+        assistant_message: str,
+        attached_figure_ids: list[str],
+    ) -> None:
+        question.solution.chat_history = (
+            question.solution.chat_history
+            + [
+                ChatTurn(
+                    user_message=user_message.strip(),
+                    assistant_message=assistant_message.strip(),
+                    attached_figure_ids=attached_figure_ids[:],
+                )
+            ]
+        )[-5:]
 
     def _compute_answer_preview(question: Question | None) -> dict[str, str]:
         """Build the non-editable answer preview payload for the editor UI."""
@@ -559,70 +756,34 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
         typed_solution_md: str = Form(""),
         typed_solution_status: str = Form("missing"),
         figures_json: str = Form("[]"),
+        chat_history_json: str = Form("[]"),
     ) -> RedirectResponse:
         existing = None
         try:
             existing = repo.get_question(question_id)
         except Exception:
             existing = None
-        figures = json.loads(figures_json or "[]")
-        solution_parameters = parse_parameters_yaml(solution_parameters_yaml)
-        distractor_funcs = parse_distractor_functions_text(distractor_functions_text)
-        mc_answer_specs = parse_mc_answer_specs_json(mc_answer_specs_json)
-        mc_preview = _compute_mc_preview(
-            answer_formula_md, mc_answer_specs, solution_parameters
-        )
-        if question_type == QuestionType.multiple_choice.value and mc_answer_specs:
-            choices = mc_preview["choices"]
-        else:
-            choices = parse_choices_yaml(choices_yaml)
-        question = Question.model_validate(
+        question, _, _ = _build_question_from_editor_values(
+            question_id,
+            existing,
             {
-                "id": question_id,
                 "title": title,
                 "points": points,
-                "is_deleted": (existing.is_deleted if existing else False),
-                "question_type": QuestionType(question_type),
+                "question_type": question_type,
                 "mc_options_guidance": mc_options_guidance,
-                "choices": choices,
-                "solution": {
-                    "question_template_md": normalize_markdown_math_delimiters(
-                        question_template_md
-                    ),
-                    "parameters": solution_parameters,
-                    "answer_formula_md": answer_formula_md,
-                    "answer_guidance": answer_guidance,
-                    "mc_answer_specs": mc_answer_specs,
-                    "distractor_python_code": distractor_funcs,
-                    "typed_solution_md": normalize_markdown_math_delimiters(
-                        typed_solution_md
-                        if typed_solution_md
-                        else (existing.solution.typed_solution_md if existing else "")
-                    ),
-                    "typed_solution_status": typed_solution_status,
-                    "last_computed_answer_md": (
-                        normalize_markdown_math_delimiters(
-                            existing.solution.last_computed_answer_md
-                        )
-                        if existing
-                        else ""
-                    ),
-                },
-                "figures": figures,
-            }
+                "question_template_md": question_template_md,
+                "solution_parameters_yaml": solution_parameters_yaml,
+                "answer_formula_md": answer_formula_md,
+                "answer_guidance": answer_guidance,
+                "distractor_functions_text": distractor_functions_text,
+                "mc_answer_specs_json": mc_answer_specs_json,
+                "typed_solution_md": typed_solution_md,
+                "typed_solution_status": typed_solution_status,
+                "choices_yaml": choices_yaml,
+                "figures_json": figures_json,
+                "chat_history_json": chat_history_json,
+            },
         )
-        preview = _compute_answer_preview(question)
-        mc_preview = _compute_mc_preview(
-            question.solution.answer_formula_md,
-            question.solution.mc_answer_specs,
-            question.solution.parameters,
-        )
-        if not preview["fatal_error"]:
-            question.solution.last_computed_answer_md = (
-                preview["rendered_answer_md"]
-                or question.solution.last_computed_answer_md
-            )
-        _mark_typed_solution_stale_if_needed(existing, question)
         repo.save_question(question)
         return RedirectResponse("/", status_code=303)
 
@@ -636,68 +797,27 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
                 existing = repo.get_question(question_id)
             except Exception:
                 existing = None
-            figures = json.loads(payload.figures_json or "[]")
-            solution_parameters = parse_parameters_yaml(
-                payload.solution_parameters_yaml
-            )
-            distractor_funcs = parse_distractor_functions_text(
-                payload.distractor_functions_text
-            )
-            mc_answer_specs = parse_mc_answer_specs_json(payload.mc_answer_specs_json)
-            mc_preview = _compute_mc_preview(
-                payload.answer_formula_md, mc_answer_specs, solution_parameters
-            )
-            if (
-                payload.question_type == QuestionType.multiple_choice.value
-                and mc_answer_specs
-            ):
-                choices = mc_preview["choices"]
-            else:
-                choices = parse_choices_yaml(payload.choices_yaml)
-            question = Question.model_validate(
+            question, preview, mc_preview = _build_question_from_editor_values(
+                question_id,
+                existing,
                 {
-                    "id": question_id,
                     "title": payload.title,
-                    "question_type": QuestionType(payload.question_type),
-                    "mc_options_guidance": payload.mc_options_guidance,
-                    "choices": choices,
-                    "solution": {
-                        "question_template_md": normalize_markdown_math_delimiters(
-                            payload.question_template_md
-                        ),
-                        "parameters": solution_parameters,
-                        "answer_formula_md": payload.answer_formula_md,
-                        "answer_guidance": payload.answer_guidance,
-                        "mc_answer_specs": mc_answer_specs,
-                        "distractor_python_code": distractor_funcs,
-                        "typed_solution_md": normalize_markdown_math_delimiters(
-                            payload.typed_solution_md
-                            if payload.typed_solution_md
-                            else (
-                                existing.solution.typed_solution_md if existing else ""
-                            )
-                        ),
-                        "typed_solution_status": payload.typed_solution_status,
-                        "last_computed_answer_md": (
-                            normalize_markdown_math_delimiters(
-                                existing.solution.last_computed_answer_md
-                            )
-                            if existing
-                            else ""
-                        ),
-                    },
-                    "figures": figures,
                     "points": payload.points,
-                    "is_deleted": (existing.is_deleted if existing else False),
-                }
+                    "question_type": payload.question_type,
+                    "mc_options_guidance": payload.mc_options_guidance,
+                    "question_template_md": payload.question_template_md,
+                    "solution_parameters_yaml": payload.solution_parameters_yaml,
+                    "answer_formula_md": payload.answer_formula_md,
+                    "answer_guidance": payload.answer_guidance,
+                    "distractor_functions_text": payload.distractor_functions_text,
+                    "mc_answer_specs_json": payload.mc_answer_specs_json,
+                    "typed_solution_md": payload.typed_solution_md,
+                    "typed_solution_status": payload.typed_solution_status,
+                    "choices_yaml": payload.choices_yaml,
+                    "figures_json": payload.figures_json,
+                    "chat_history_json": payload.chat_history_json,
+                },
             )
-            preview = _compute_answer_preview(question)
-            if not preview["fatal_error"]:
-                question.solution.last_computed_answer_md = (
-                    preview["rendered_answer_md"]
-                    or question.solution.last_computed_answer_md
-                )
-            _mark_typed_solution_stale_if_needed(existing, question)
             repo.save_question(question)
             return JSONResponse(
                 {
@@ -742,6 +862,77 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
         q = repo.get_question(question_id)
         errors = validate_question(q)
         return {"question_id": question_id, "errors": errors, "ok": not errors}
+
+    @app.post("/questions/{question_id}/ai/chat")
+    def ai_chat(question_id: str, payload: ChatPayload = Body(...)) -> dict:
+        try:
+            existing = None
+            try:
+                existing = repo.get_question(question_id)
+            except Exception:
+                existing = None
+            live_question, _, _ = _build_question_from_editor_values(
+                question_id,
+                existing,
+                {
+                    "title": payload.editor_state.title,
+                    "points": payload.editor_state.points,
+                    "question_type": payload.editor_state.question_type,
+                    "mc_options_guidance": payload.editor_state.mc_options_guidance,
+                    "question_template_md": payload.editor_state.question_template_md,
+                    "solution_parameters_yaml": payload.editor_state.solution_parameters_yaml,
+                    "answer_formula_md": payload.editor_state.answer_formula_md,
+                    "answer_guidance": payload.editor_state.answer_guidance,
+                    "distractor_functions_text": payload.editor_state.distractor_functions_text,
+                    "mc_answer_specs_json": payload.editor_state.mc_answer_specs_json,
+                    "typed_solution_md": payload.editor_state.typed_solution_md,
+                    "typed_solution_status": payload.editor_state.typed_solution_status,
+                    "choices_yaml": payload.editor_state.choices_yaml,
+                    "figures_json": payload.editor_state.figures_json,
+                    "chat_history_json": payload.editor_state.chat_history_json,
+                },
+            )
+            result = app.state.ai.chat_edit_question(
+                live_question,
+                payload.message,
+                attached_figure_ids=payload.attached_figure_ids,
+            )
+            repo.add_ai_usage(result.usage)
+            question = result.question
+            _append_chat_turn(
+                question,
+                user_message=payload.message,
+                assistant_message=result.assistant_message,
+                attached_figure_ids=payload.attached_figure_ids,
+            )
+            preview = _compute_answer_preview(question)
+            mc_preview = _compute_mc_preview(
+                question.solution.answer_formula_md,
+                question.solution.mc_answer_specs,
+                question.solution.parameters,
+            )
+            repo.save_question(question)
+            editor_values = _editor_values_from_question(question)
+            return {
+                "ok": True,
+                "assistant_message": result.assistant_message,
+                "warnings": result.warnings,
+                "changed_fields": result.changed_fields + ["chat_history_json"],
+                **editor_values,
+                "calculated_variables_md": preview["calculated_variables_md"],
+                "rendered_answer_md": (
+                    question.solution.last_computed_answer_md
+                    or preview["rendered_answer_md"]
+                ),
+                "answer_formula_warning": preview["warning"],
+                "mc_preview_choices": mc_preview["preview_choices"],
+                "mc_preview_answers": mc_preview["preview_answers"],
+                "mc_preview_rationale": mc_preview["preview_rationale"],
+                "mc_preview_warning": mc_preview["warning"],
+                "mc_preview_rows": mc_preview["rows"],
+            }
+        except Exception as ex:
+            return JSONResponse({"ok": False, "error": str(ex)}, status_code=422)
 
     @app.post("/questions/{question_id}/ai/rewrite-and-parameterize")
     def ai_rewrite_and_parameterize(question_id: str) -> dict:

--- a/src/exam_helper/app.py
+++ b/src/exam_helper/app.py
@@ -906,6 +906,10 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
                 attached_figure_ids=payload.attached_figure_ids,
             )
             preview = _compute_answer_preview(question)
+            if not preview["fatal_error"]:
+                question.solution.last_computed_answer_md = preview[
+                    "rendered_answer_md"
+                ]
             mc_preview = _compute_mc_preview(
                 question.solution.answer_formula_md,
                 question.solution.mc_answer_specs,
@@ -920,10 +924,7 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
                 "changed_fields": result.changed_fields + ["chat_history_json"],
                 **editor_values,
                 "calculated_variables_md": preview["calculated_variables_md"],
-                "rendered_answer_md": (
-                    question.solution.last_computed_answer_md
-                    or preview["rendered_answer_md"]
-                ),
+                "rendered_answer_md": preview["rendered_answer_md"],
                 "answer_formula_warning": preview["warning"],
                 "mc_preview_choices": mc_preview["preview_choices"],
                 "mc_preview_answers": mc_preview["preview_answers"],

--- a/src/exam_helper/models.py
+++ b/src/exam_helper/models.py
@@ -57,6 +57,12 @@ class DistractorFunction(BaseModel):
         return v
 
 
+class ChatTurn(BaseModel):
+    user_message: str = ""
+    assistant_message: str = ""
+    attached_figure_ids: list[str] = Field(default_factory=list)
+
+
 class Solution(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
@@ -69,6 +75,7 @@ class Solution(BaseModel):
     typed_solution_md: str = ""
     typed_solution_status: Literal["missing", "fresh", "stale"] = "missing"
     last_computed_answer_md: str = ""
+    chat_history: list[ChatTurn] = Field(default_factory=list)
 
 
 class Question(BaseModel):

--- a/src/exam_helper/templates/question_form_v2.html
+++ b/src/exam_helper/templates/question_form_v2.html
@@ -207,6 +207,9 @@
         display: grid;
         gap: 0.85rem;
       }
+      .chat-panel.is-busy {
+        opacity: 0.78;
+      }
       .chat-log {
         display: grid;
         gap: 0.7rem;
@@ -314,15 +317,26 @@
           <input name="title" id="title" value="{{ question.title if question else '' }}" />
         </div>
 
-        <div class="card chat-panel">
+        <div class="card chat-panel" aria-disabled="{{ 'false' if ai_enabled else 'true' }}" title="{{ 'No API key configured' if not ai_enabled else 'Chat Assistant' }}">
           <label for="chat_message">Chat Assistant</label>
-          <p class="hint">Ask for a rewrite, a cleanup pass, a distractor tweak, or a question-specific edit. Use Shift+Enter for a newline.</p>
+          <p class="hint">{{ 'Ask for a rewrite, a cleanup pass, a distractor tweak, or a question-specific edit. Enter adds a newline. Use Shift+Enter to send.' if ai_enabled else 'Chat is disabled until an OpenAI key is configured.' }}</p>
           <div id="chat_thread" class="chat-log" aria-live="polite"></div>
           <div class="chat-input-row">
-            <textarea id="chat_message" placeholder="e.g. Please turn this rough prompt into a cleaner exam question."></textarea>
+            <textarea
+              id="chat_message"
+              placeholder="e.g. Please turn this rough prompt into a cleaner exam question."
+              title="{{ 'Enter adds a newline. Use Shift+Enter to send.' if ai_enabled else 'No API key configured.' }}"
+              {% if not ai_enabled %}disabled{% endif %}
+            ></textarea>
             <div id="chat_attachments" class="chat-attachments"></div>
             <div class="actions">
-              <button type="button" class="btn" id="btn_send_chat">Send</button>
+              <button
+                type="button"
+                class="btn"
+                id="btn_send_chat"
+                title="Shift+Enter to send"
+                {% if not ai_enabled %}disabled{% endif %}
+              >Send</button>
               <span id="chat_status" class="status"></span>
             </div>
           </div>
@@ -449,6 +463,8 @@
       const chatSendBtn = document.getElementById("btn_send_chat");
       const chatStatusEl = document.getElementById("chat_status");
       const chatAttachmentsEl = document.getElementById("chat_attachments");
+      const chatPanelEl = document.querySelector(".chat-panel");
+      const chatEnabled = {{ 'true' if ai_enabled else 'false' }};
       let autosaveTimer = null;
       let pendingChatFigureIds = [];
 
@@ -460,6 +476,14 @@
       function setChatStatus(text, cls) {
         chatStatusEl.textContent = text;
         chatStatusEl.className = `status ${cls || ""}`;
+      }
+
+      function setChatBusy(isBusy) {
+        const disabled = !chatEnabled || isBusy;
+        chatSendBtn.disabled = disabled;
+        chatMessageEl.disabled = disabled;
+        chatPanelEl.classList.toggle("is-busy", isBusy);
+        chatPanelEl.setAttribute("aria-busy", isBusy ? "true" : "false");
       }
 
       function isMC() {
@@ -821,12 +845,12 @@
         if (typeof data.calculated_variables_md === "string") {
           calculatedVariablesEl.textContent = data.calculated_variables_md;
         }
-        if (typeof data.rendered_answer_md === "string") {
-          renderMarkdownSurface(renderedAnswerEl, data.rendered_answer_md);
-        }
         renderTemplate();
         renderMCPreviewFromData(data);
         renderFiguresPreview();
+        if (typeof data.rendered_answer_md === "string") {
+          renderMarkdownSurface(renderedAnswerEl, data.rendered_answer_md);
+        }
         updateMCVisibility();
       }
 
@@ -844,9 +868,12 @@
         const qid = questionIdEl.value.trim();
         const message = chatMessageEl.value.trim();
         if (!qid || !message) return;
+        if (!chatEnabled) {
+          setChatStatus("Chat is disabled: no API key configured.", "warn");
+          return;
+        }
         if (autosaveTimer) clearTimeout(autosaveTimer);
-        chatSendBtn.disabled = true;
-        chatMessageEl.disabled = true;
+        setChatBusy(true);
         const attachedFigureIds = pendingChatFigureIds.slice();
         setChatStatus("Thinking...", "warn");
         renderChatMessage("user", message, attachedFigureIds);
@@ -873,8 +900,7 @@
           setChatStatus(`Chat error: ${err.message}`, "warn");
           renderChatMessage("assistant", `Error: ${err.message}`);
         } finally {
-          chatSendBtn.disabled = false;
-          chatMessageEl.disabled = false;
+          setChatBusy(false);
           chatMessageEl.focus();
         }
       }
@@ -1053,7 +1079,7 @@
         sendChatMessage().catch((err) => setChatStatus(`Chat error: ${err.message}`, "warn"));
       });
       chatMessageEl.addEventListener("keydown", (event) => {
-        if (event.key === "Enter" && !event.shiftKey) {
+        if (event.key === "Enter" && event.shiftKey) {
           event.preventDefault();
           sendChatMessage().catch((err) => setChatStatus(`Chat error: ${err.message}`, "warn"));
         }
@@ -1081,12 +1107,8 @@
           renderChatMessage("user", turn.user_message || "", turn.attached_figure_ids || []);
           renderChatMessage("assistant", turn.assistant_message || "");
         }
-      } else {
-        renderChatMessage(
-          "assistant",
-          "{{ 'OpenAI chat is enabled.' if ai_enabled else 'Configure an OpenAI key to use chat.' }}"
-        );
       }
+      setChatBusy(false);
       renderPendingChatAttachments();
     </script>
   </body>

--- a/src/exam_helper/templates/question_form_v2.html
+++ b/src/exam_helper/templates/question_form_v2.html
@@ -121,6 +121,9 @@
         white-space: pre-wrap;
         font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
       }
+      .formula-preview--compact {
+        min-height: 0;
+      }
       .status {
         min-height: 1.2rem;
         color: var(--muted);
@@ -395,7 +398,7 @@
                 <textarea id="mc_answer_{{ loop.index }}_formula_md" data-mc-formula name="mc_answer_{{ loop.index }}_formula_md">{{ row.formula_md }}</textarea>
                 <label for="mc_answer_{{ loop.index }}_rationale_md">Rationale</label>
                 <textarea id="mc_answer_{{ loop.index }}_rationale_md" data-mc-rationale name="mc_answer_{{ loop.index }}_rationale_md">{{ row.rationale_md }}</textarea>
-                <div class="formula-preview" id="mc_answer_{{ loop.index }}_preview" aria-readonly="true">{{ row.preview_md }}</div>
+                <div class="formula-preview formula-preview--compact" id="mc_answer_{{ loop.index }}_preview" aria-readonly="true">{{ row.preview_md }}</div>
                 <p class="mc-row-warning" id="mc_answer_{{ loop.index }}_warning">{{ row.warning }}</p>
               </div>
             {% endfor %}

--- a/src/exam_helper/templates/question_form_v2.html
+++ b/src/exam_helper/templates/question_form_v2.html
@@ -683,6 +683,21 @@
         return specs;
       }
 
+      function syncMCRowsFromSpecs(specs) {
+        const rows = document.querySelectorAll("[data-mc-row]");
+        rows.forEach((row, idx) => {
+          const formula = row.querySelector("[data-mc-formula]");
+          const rationale = row.querySelector("[data-mc-rationale]");
+          const spec = Array.isArray(specs) ? specs[idx] || {} : {};
+          if (formula) {
+            formula.value = typeof spec.formula_md === "string" ? spec.formula_md : "";
+          }
+          if (rationale) {
+            rationale.value = typeof spec.rationale_md === "string" ? spec.rationale_md : "";
+          }
+        });
+      }
+
       function renderMCPreviewFromData(data) {
         if (!isMC()) {
           mcPreviewAnswers.innerHTML = "";
@@ -796,7 +811,10 @@
         if (typeof data.answer_guidance === "string") answerGuidanceEl.value = data.answer_guidance;
         if (typeof data.mc_options_guidance === "string") mcOptionsGuidanceEl.value = data.mc_options_guidance;
         if (typeof data.distractor_functions_text === "string") distractorFnsEl.value = data.distractor_functions_text;
-        if (typeof data.mc_answer_specs_json === "string") mcAnswerSpecsEl.value = data.mc_answer_specs_json;
+        if (typeof data.mc_answer_specs_json === "string") {
+          mcAnswerSpecsEl.value = data.mc_answer_specs_json;
+          syncMCRowsFromSpecs(parseMCSpecs());
+        }
         if (typeof data.chat_history_json === "string") chatHistoryEl.value = data.chat_history_json;
         if (typeof data.figures_json === "string") figuresInput.value = data.figures_json;
         if (typeof data.typed_solution_status === "string") typedStatusEl.value = data.typed_solution_status;

--- a/src/exam_helper/templates/question_form_v2.html
+++ b/src/exam_helper/templates/question_form_v2.html
@@ -203,6 +203,61 @@
         font-size: 0.92rem;
         min-height: 1.1rem;
       }
+      .chat-panel {
+        display: grid;
+        gap: 0.85rem;
+      }
+      .chat-log {
+        display: grid;
+        gap: 0.7rem;
+        max-height: 280px;
+        overflow: auto;
+        border: 1px solid var(--line);
+        border-radius: 16px;
+        background: #fff;
+        padding: 0.85rem;
+      }
+      .chat-message {
+        border-radius: 14px;
+        padding: 0.75rem 0.85rem;
+        max-width: 88%;
+      }
+      .chat-message.user {
+        justify-self: end;
+        background: var(--accent-soft);
+      }
+      .chat-message.assistant {
+        justify-self: start;
+        background: #fff;
+        border: 1px solid #eadfcf;
+      }
+      .chat-role {
+        font-size: 0.78rem;
+        font-weight: 700;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        color: var(--muted);
+        margin-bottom: 0.35rem;
+      }
+      .chat-input-row {
+        display: grid;
+        gap: 0.6rem;
+      }
+      .chat-input-row textarea {
+        min-height: 92px;
+      }
+      .chat-attachments {
+        display: flex;
+        gap: 0.5rem;
+        flex-wrap: wrap;
+      }
+      .chat-attachment {
+        border: 1px solid var(--line);
+        border-radius: 999px;
+        padding: 0.3rem 0.6rem;
+        background: #fff;
+        font-size: 0.9rem;
+      }
       @media (max-width: 900px) {
         .row, .row3, .mc-preview-grid {
           grid-template-columns: 1fr;
@@ -235,6 +290,7 @@
         <textarea hidden name="distractor_functions_text" id="distractor_functions_text">{{ distractor_functions_text }}</textarea>
         <textarea hidden name="mc_answer_specs_json" id="mc_answer_specs_json">{{ mc_answer_specs_json }}</textarea>
         <textarea hidden name="typed_solution_status" id="typed_solution_status">{{ question.solution.typed_solution_status if question else 'missing' }}</textarea>
+        <textarea hidden name="chat_history_json" id="chat_history_json">{{ chat_history_json }}</textarea>
         <div class="row3">
           <div class="card">
             <label>Question ID</label>
@@ -256,6 +312,20 @@
         <div class="card">
           <label>Title (optional)</label>
           <input name="title" id="title" value="{{ question.title if question else '' }}" />
+        </div>
+
+        <div class="card chat-panel">
+          <label for="chat_message">Chat Assistant</label>
+          <p class="hint">Ask for a rewrite, a cleanup pass, a distractor tweak, or a question-specific edit. Use Shift+Enter for a newline.</p>
+          <div id="chat_thread" class="chat-log" aria-live="polite"></div>
+          <div class="chat-input-row">
+            <textarea id="chat_message" placeholder="e.g. Please turn this rough prompt into a cleaner exam question."></textarea>
+            <div id="chat_attachments" class="chat-attachments"></div>
+            <div class="actions">
+              <button type="button" class="btn" id="btn_send_chat">Send</button>
+              <span id="chat_status" class="status"></span>
+            </div>
+          </div>
         </div>
 
         <div class="row">
@@ -359,6 +429,7 @@
       const mcOptionsGuidanceEl = document.getElementById("mc_options_guidance");
       const distractorFnsEl = document.getElementById("distractor_functions_text");
       const mcAnswerSpecsEl = document.getElementById("mc_answer_specs_json");
+      const chatHistoryEl = document.getElementById("chat_history_json");
       const renderedAnswerEl = document.getElementById("rendered_answer_md");
       const calculatedVariablesEl = document.getElementById("calculated_variables_md");
       const answerFormulaWarningEl = document.getElementById("answer_formula_warning");
@@ -373,11 +444,22 @@
       const mcPreviewAnswers = document.getElementById("mc_preview_answers");
       const mcPreviewRationale = document.getElementById("mc_preview_rationale");
       const mcPreviewWarning = document.getElementById("mc_preview_warning");
+      const chatThreadEl = document.getElementById("chat_thread");
+      const chatMessageEl = document.getElementById("chat_message");
+      const chatSendBtn = document.getElementById("btn_send_chat");
+      const chatStatusEl = document.getElementById("chat_status");
+      const chatAttachmentsEl = document.getElementById("chat_attachments");
       let autosaveTimer = null;
+      let pendingChatFigureIds = [];
 
       function setStatus(text, cls) {
         saveStatus.textContent = text;
         saveStatus.className = `status ${cls || ""}`;
+      }
+
+      function setChatStatus(text, cls) {
+        chatStatusEl.textContent = text;
+        chatStatusEl.className = `status ${cls || ""}`;
       }
 
       function isMC() {
@@ -411,6 +493,15 @@
       function setFigures(figures) {
         figuresInput.value = JSON.stringify(figures);
         renderFiguresPreview();
+      }
+
+      function parseChatHistory() {
+        try {
+          const parsed = JSON.parse(chatHistoryEl.value || "[]");
+          return Array.isArray(parsed) ? parsed : [];
+        } catch {
+          return [];
+        }
       }
 
       function nextFigureId(figures) {
@@ -509,6 +600,22 @@
         renderTemplate();
         scheduleAutosave();
         setStatus(`Added ${pendingId}`, "good");
+        return true;
+      }
+
+      async function addChatAttachmentFromFile(file) {
+        if (!file || !String(file.type || "").startsWith("image/")) return false;
+        const figures = parseFigures();
+        const pendingId = nextFigureId(figures);
+        setChatStatus("Processing chat image...", "warn");
+        const figure = await buildFigureFromFile(file);
+        figure.id = pendingId;
+        figures.push(figure);
+        setFigures(figures);
+        pendingChatFigureIds.push(pendingId);
+        renderPendingChatAttachments();
+        scheduleAutosave();
+        setChatStatus(`Attached ${pendingId}`, "good");
         return true;
       }
 
@@ -654,6 +761,106 @@
         }
       }
 
+      function renderPendingChatAttachments() {
+        if (!pendingChatFigureIds.length) {
+          chatAttachmentsEl.innerHTML = "";
+          return;
+        }
+        chatAttachmentsEl.innerHTML = pendingChatFigureIds.map((id) => (
+          `<span class="chat-attachment">${escapeHtml(id)}</span>`
+        )).join("");
+      }
+
+      function renderChatMessage(role, text, attachedFigureIds = []) {
+        const item = document.createElement("div");
+        item.className = `chat-message ${role}`;
+        const attachments = Array.isArray(attachedFigureIds) && attachedFigureIds.length
+          ? `<div class="hint">Figures: ${attachedFigureIds.map((id) => escapeHtml(id)).join(", ")}</div>`
+          : "";
+        item.innerHTML = `
+          <div class="chat-role">${role === "assistant" ? "Assistant" : "You"}</div>
+          <div>${escapeHtml(String(text || "")).replace(/\n/g, "<br>")}</div>
+          ${attachments}
+        `;
+        chatThreadEl.appendChild(item);
+        chatThreadEl.scrollTop = chatThreadEl.scrollHeight;
+      }
+
+      function setEditorValuesFromResponse(data) {
+        if (typeof data.title === "string") titleEl.value = data.title;
+        if (Object.prototype.hasOwnProperty.call(data, "points")) pointsEl.value = data.points;
+        if (typeof data.question_type === "string") questionTypeEl.value = data.question_type;
+        if (typeof data.question_template_md === "string") templateEl.value = data.question_template_md;
+        if (typeof data.solution_parameters_yaml === "string") paramsEl.value = data.solution_parameters_yaml;
+        if (typeof data.answer_formula_md === "string") answerFormulaEl.value = data.answer_formula_md;
+        if (typeof data.answer_guidance === "string") answerGuidanceEl.value = data.answer_guidance;
+        if (typeof data.mc_options_guidance === "string") mcOptionsGuidanceEl.value = data.mc_options_guidance;
+        if (typeof data.distractor_functions_text === "string") distractorFnsEl.value = data.distractor_functions_text;
+        if (typeof data.mc_answer_specs_json === "string") mcAnswerSpecsEl.value = data.mc_answer_specs_json;
+        if (typeof data.chat_history_json === "string") chatHistoryEl.value = data.chat_history_json;
+        if (typeof data.figures_json === "string") figuresInput.value = data.figures_json;
+        if (typeof data.typed_solution_status === "string") typedStatusEl.value = data.typed_solution_status;
+        if (typeof data.calculated_variables_md === "string") {
+          calculatedVariablesEl.textContent = data.calculated_variables_md;
+        }
+        if (typeof data.rendered_answer_md === "string") {
+          renderMarkdownSurface(renderedAnswerEl, data.rendered_answer_md);
+        }
+        renderTemplate();
+        renderMCPreviewFromData(data);
+        renderFiguresPreview();
+        updateMCVisibility();
+      }
+
+      function applyAssistantResponse(data) {
+        setEditorValuesFromResponse(data);
+        if (Array.isArray(data.warnings) && data.warnings.length) {
+          setChatStatus(data.warnings.join(" | "), "warn");
+        } else {
+          setChatStatus("Saved", "good");
+        }
+        setStatus("Updated via chat", "good");
+      }
+
+      async function sendChatMessage() {
+        const qid = questionIdEl.value.trim();
+        const message = chatMessageEl.value.trim();
+        if (!qid || !message) return;
+        if (autosaveTimer) clearTimeout(autosaveTimer);
+        chatSendBtn.disabled = true;
+        chatMessageEl.disabled = true;
+        const attachedFigureIds = pendingChatFigureIds.slice();
+        setChatStatus("Thinking...", "warn");
+        renderChatMessage("user", message, attachedFigureIds);
+        chatMessageEl.value = "";
+        try {
+          const res = await fetch(`/questions/${qid}/ai/chat`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              message,
+              attached_figure_ids: attachedFigureIds,
+              editor_state: serializePayload(),
+            }),
+          });
+          const data = await res.json();
+          if (!res.ok || !data.ok) {
+            throw new Error(data.error || res.statusText || "Chat update failed.");
+          }
+          renderChatMessage("assistant", data.assistant_message || "(no response)");
+          applyAssistantResponse(data);
+          pendingChatFigureIds = [];
+          renderPendingChatAttachments();
+        } catch (err) {
+          setChatStatus(`Chat error: ${err.message}`, "warn");
+          renderChatMessage("assistant", `Error: ${err.message}`);
+        } finally {
+          chatSendBtn.disabled = false;
+          chatMessageEl.disabled = false;
+          chatMessageEl.focus();
+        }
+      }
+
       function updateMCVisibility() {
         mcBlock.style.display = isMC() ? "block" : "none";
       }
@@ -672,6 +879,7 @@
           mc_answer_specs_json: mcAnswerSpecsEl.value,
           typed_solution_status: typedStatusEl.value,
           figures_json: figuresInput.value || "[]",
+          chat_history_json: chatHistoryEl.value || "[]",
           points: Number(pointsEl.value || 5),
         };
       }
@@ -772,6 +980,19 @@
         }
       });
 
+      chatMessageEl.addEventListener("paste", async (event) => {
+        const files = extractImageFilesFromClipboard(event);
+        if (!files.length) return;
+        event.preventDefault();
+        try {
+          for (const file of files) {
+            await addChatAttachmentFromFile(file);
+          }
+        } catch (err) {
+          setChatStatus(`Chat image error: ${err.message}`, "warn");
+        }
+      });
+
       document.addEventListener("dragover", (event) => {
         const hasImage = Array.from(event.dataTransfer?.items || []).some((item) => item.kind === "file" && String(item.type || "").startsWith("image/"));
         if (hasImage) {
@@ -790,6 +1011,13 @@
         if (!files.length) return;
         event.preventDefault();
         try {
+          const dropTarget = event.target instanceof Element ? event.target.closest(".chat-panel") : null;
+          if (dropTarget) {
+            for (const file of files) {
+              await addChatAttachmentFromFile(file);
+            }
+            return;
+          }
           const appendFallback = document.activeElement !== templateEl;
           for (const file of files) {
             await addFigureFromFile(file, appendFallback);
@@ -801,6 +1029,16 @@
 
       form.addEventListener("submit", () => {
         setStatus("Saving...", "warn");
+      });
+
+      chatSendBtn.addEventListener("click", () => {
+        sendChatMessage().catch((err) => setChatStatus(`Chat error: ${err.message}`, "warn"));
+      });
+      chatMessageEl.addEventListener("keydown", (event) => {
+        if (event.key === "Enter" && !event.shiftKey) {
+          event.preventDefault();
+          sendChatMessage().catch((err) => setChatStatus(`Chat error: ${err.message}`, "warn"));
+        }
       });
 
       renderTemplate();
@@ -819,6 +1057,19 @@
       renderMarkdownSurface(renderedAnswerEl, renderedAnswerEl.textContent || "");
       updateMCVisibility();
       renderFiguresPreview();
+      const existingChatHistory = parseChatHistory();
+      if (existingChatHistory.length) {
+        for (const turn of existingChatHistory) {
+          renderChatMessage("user", turn.user_message || "", turn.attached_figure_ids || []);
+          renderChatMessage("assistant", turn.assistant_message || "");
+        }
+      } else {
+        renderChatMessage(
+          "assistant",
+          "{{ 'OpenAI chat is enabled.' if ai_enabled else 'Configure an OpenAI key to use chat.' }}"
+        );
+      }
+      renderPendingChatAttachments();
     </script>
   </body>
 </html>

--- a/src/exam_helper/templates/question_form_v2.html
+++ b/src/exam_helper/templates/question_form_v2.html
@@ -123,6 +123,9 @@
       }
       .formula-preview--compact {
         min-height: 0;
+        display: inline-block;
+        width: fit-content;
+        max-width: 100%;
       }
       .status {
         min-height: 1.2rem;
@@ -755,7 +758,14 @@
           const warningEl = document.getElementById(`mc_answer_${idx + 1}_warning`);
           if (previewEl) {
             const previewText = String(row?.preview_md || "");
-            previewEl.innerHTML = previewText ? marked.parse(normalizeMathDelimitersForPreview(previewText)) : "";
+            if (previewText) {
+              previewEl.innerHTML = "";
+              previewEl.innerHTML = marked.parseInline(
+                normalizeMathDelimitersForPreview(previewText)
+              );
+            } else {
+              previewEl.innerHTML = "";
+            }
           }
           if (warningEl) {
             warningEl.textContent = row?.warning ? `Warning: ${row.warning}` : "";

--- a/tests/integration/test_app_ai_config_and_usage.py
+++ b/tests/integration/test_app_ai_config_and_usage.py
@@ -60,6 +60,37 @@ def test_question_editor_has_new_workflow_hooks(tmp_path) -> None:
     assert redirect.headers["location"] == "/questions/q_edit/edit2"
 
 
+def test_question_editor_v2_has_chat_hooks(tmp_path) -> None:
+    repo = ProjectRepository(tmp_path)
+    repo.init_project("Exam", "Physics")
+    app = create_app(tmp_path, openai_key=None)
+    client = TestClient(app)
+    client.post(
+        "/questions/save",
+        data={
+            "question_id": "q_edit2",
+            "title": "T",
+            "question_type": "free_response",
+            "prompt_md": "P",
+            "question_template_md": "P",
+            "choices_yaml": "[]",
+            "typed_solution_md": "",
+            "distractor_functions_text": "",
+            "figures_json": "[]",
+            "points": 5,
+        },
+    )
+    resp = client.get("/questions/q_edit2/edit2")
+    assert resp.status_code == 200
+    assert 'id="chat_thread"' in resp.text
+    assert 'id="chat_message"' in resp.text
+    assert 'id="btn_send_chat"' in resp.text
+    assert (
+        "OpenAI chat is enabled." in resp.text
+        or "Configure an OpenAI key to use chat." in resp.text
+    )
+
+
 def test_usage_totals_accumulate_and_reset(tmp_path) -> None:
     repo = ProjectRepository(tmp_path)
     repo.init_project("Exam", "Physics")

--- a/tests/integration/test_app_ai_config_and_usage.py
+++ b/tests/integration/test_app_ai_config_and_usage.py
@@ -85,6 +85,7 @@ def test_question_editor_v2_has_chat_hooks(tmp_path) -> None:
     assert 'id="chat_thread"' in resp.text
     assert 'id="chat_message"' in resp.text
     assert 'id="btn_send_chat"' in resp.text
+    assert "formula-preview--compact" in resp.text
     assert "OpenAI chat is enabled." not in resp.text
     assert "Configure an OpenAI key to use chat." not in resp.text
     assert "No API key configured" in resp.text

--- a/tests/integration/test_app_ai_config_and_usage.py
+++ b/tests/integration/test_app_ai_config_and_usage.py
@@ -85,10 +85,13 @@ def test_question_editor_v2_has_chat_hooks(tmp_path) -> None:
     assert 'id="chat_thread"' in resp.text
     assert 'id="chat_message"' in resp.text
     assert 'id="btn_send_chat"' in resp.text
-    assert (
-        "OpenAI chat is enabled." in resp.text
-        or "Configure an OpenAI key to use chat." in resp.text
-    )
+    assert "OpenAI chat is enabled." not in resp.text
+    assert "Configure an OpenAI key to use chat." not in resp.text
+    assert "No API key configured" in resp.text
+    assert 'title="Shift+Enter to send"' in resp.text
+    assert 'title="No API key configured."' in resp.text
+    assert "setChatBusy(true)" in resp.text
+    assert 'event.key === "Enter" && event.shiftKey' in resp.text
 
 
 def test_usage_totals_accumulate_and_reset(tmp_path) -> None:

--- a/tests/integration/test_autosave_and_ai_errors.py
+++ b/tests/integration/test_autosave_and_ai_errors.py
@@ -1,10 +1,18 @@
 from __future__ import annotations
 
+import json
+
 from fastapi.testclient import TestClient
 
 from exam_helper.ai_service import AIService
 from exam_helper.app import create_app
-from exam_helper.models import AIUsageTotals, DistractorFunction
+from exam_helper.models import (
+    AIUsageTotals,
+    ChatTurn,
+    DistractorFunction,
+    MCAnswerSpec,
+    Question,
+)
 from exam_helper.repository import ProjectRepository
 
 
@@ -27,6 +35,47 @@ def _seed_question(client: TestClient, qid: str, qtype: str = "free_response") -
             "points": 5,
         },
     )
+
+
+def _editor_state_for_question(question: Question) -> dict[str, object]:
+    distractor_functions_text = ""
+    if question.solution.distractor_python_code:
+        distractor_functions_text = (
+            "\n---\n".join(
+                [
+                    f"# distractor: {d.id}\n{(d.python_code or '').strip()}"
+                    for d in question.solution.distractor_python_code
+                ]
+            ).strip()
+            + "\n"
+        )
+    return {
+        "title": question.title,
+        "question_type": question.question_type.value,
+        "mc_options_guidance": question.mc_options_guidance,
+        "question_template_md": question.solution.question_template_md,
+        "solution_parameters_yaml": (
+            "{}"
+            if not question.solution.parameters
+            else json.dumps(question.solution.parameters)
+        ),
+        "answer_formula_md": question.solution.answer_formula_md,
+        "answer_guidance": question.solution.answer_guidance,
+        "distractor_functions_text": distractor_functions_text,
+        "mc_answer_specs_json": json.dumps(
+            [spec.model_dump(mode="json") for spec in question.solution.mc_answer_specs]
+        ),
+        "choices_yaml": "[]",
+        "typed_solution_md": question.solution.typed_solution_md,
+        "typed_solution_status": question.solution.typed_solution_status,
+        "figures_json": json.dumps(
+            [fig.model_dump(mode="json") for fig in question.figures]
+        ),
+        "chat_history_json": json.dumps(
+            [turn.model_dump(mode="json") for turn in question.solution.chat_history]
+        ),
+        "points": question.points,
+    }
 
 
 def test_autosave_marks_typed_solution_stale_on_parameter_change(tmp_path) -> None:
@@ -512,3 +561,184 @@ def test_autosave_updates_mc_options_guidance(tmp_path) -> None:
     assert resp.status_code == 200
     saved = repo.get_question("q_mc_guidance")
     assert saved.mc_options_guidance == "Use realistic sign mistakes only."
+
+
+def test_ai_chat_updates_question_and_returns_payload(tmp_path) -> None:
+    repo = ProjectRepository(tmp_path)
+    repo.init_project("Exam", "Physics")
+    app = create_app(tmp_path, openai_key="k")
+    client = TestClient(app)
+    _seed_question(client, "q_chat")
+
+    class _AI:
+        def chat_edit_question(self, question, user_message, attached_figure_ids=None):
+            assert question.id == "q_chat"
+            assert user_message == "Please clean this up."
+            assert attached_figure_ids == []
+            updated = question.model_copy(deep=True)
+            updated.title = "Cleaned title"
+            updated.solution.question_template_md = "A cleaner prompt."
+            updated.solution.chat_history = []
+            return AIService.QuestionEditorResult(
+                assistant_message="Cleaned up the prompt.",
+                question=updated,
+                warnings=["Preserved the typed solution."],
+                usage=AIUsageTotals(),
+                changed_fields=["title", "question_template_md"],
+            )
+
+    app.state.ai = _AI()
+    q = repo.get_question("q_chat")
+    resp = client.post(
+        "/questions/q_chat/ai/chat",
+        json={
+            "message": "Please clean this up.",
+            "attached_figure_ids": [],
+            "editor_state": _editor_state_for_question(q),
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["assistant_message"] == "Cleaned up the prompt."
+    assert "title" in body["changed_fields"]
+    assert body["title"] == "Cleaned title"
+    assert body["question_template_md"] == "A cleaner prompt."
+    assert body["warnings"] == ["Preserved the typed solution."]
+    saved = repo.get_question("q_chat")
+    assert saved.title == "Cleaned title"
+    assert saved.solution.question_template_md == "A cleaner prompt."
+    assert len(saved.solution.chat_history) == 1
+    assert saved.solution.chat_history[0].user_message == "Please clean this up."
+
+
+def test_ai_chat_uses_live_editor_state_and_persists_last_five_turns(tmp_path) -> None:
+    repo = ProjectRepository(tmp_path)
+    repo.init_project("Exam", "Physics")
+    app = create_app(tmp_path, openai_key="k")
+    client = TestClient(app)
+    _seed_question(client, "q_live_chat")
+    seeded = repo.get_question("q_live_chat")
+    seeded.solution.chat_history = [
+        ChatTurn(user_message=f"user {idx}", assistant_message=f"assistant {idx}")
+        for idx in range(1, 6)
+    ]
+    repo.save_question(seeded)
+
+    class _AI:
+        def chat_edit_question(self, question, user_message, attached_figure_ids=None):
+            assert question.title == "Unsaved local title"
+            assert question.solution.question_template_md == "Unsaved local template"
+            assert attached_figure_ids == ["fig_1"]
+            updated = question.model_copy(deep=True)
+            updated.solution.answer_formula_md = "answer = 12"
+            updated.solution.answer_guidance = "{{answer}}"
+            updated.solution.last_computed_answer_md = "12"
+            return AIService.QuestionEditorResult(
+                assistant_message="Stored the answer formula.",
+                question=updated,
+                warnings=[],
+                usage=AIUsageTotals(),
+                changed_fields=["answer_formula_md", "last_computed_answer_md"],
+            )
+
+    app.state.ai = _AI()
+    live_state = _editor_state_for_question(seeded)
+    live_state["title"] = "Unsaved local title"
+    live_state["question_template_md"] = "Unsaved local template"
+    live_state["figures_json"] = json.dumps(
+        [
+            {
+                "id": "fig_1",
+                "mime_type": "image/png",
+                "data_base64": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO2pG1EAAAAASUVORK5CYII=",
+                "sha256": "e8516d5fe5dff6dd2cc7f7269a4df3b741b83472ae1fbf2cbfb2aa8d0cd91015",
+                "caption": "chat attachment",
+            }
+        ]
+    )
+    live_state["chat_history_json"] = json.dumps(
+        [turn.model_dump(mode="json") for turn in seeded.solution.chat_history]
+    )
+
+    resp = client.post(
+        "/questions/q_live_chat/ai/chat",
+        json={
+            "message": "Compute the answer.",
+            "attached_figure_ids": ["fig_1"],
+            "editor_state": live_state,
+        },
+    )
+
+    assert resp.status_code == 200
+    saved = repo.get_question("q_live_chat")
+    assert saved.title == "Unsaved local title"
+    assert saved.solution.question_template_md == "Unsaved local template"
+    assert saved.solution.last_computed_answer_md == "12"
+    assert len(saved.solution.chat_history) == 5
+    assert saved.solution.chat_history[-1].user_message == "Compute the answer."
+    assert saved.solution.chat_history[-1].attached_figure_ids == ["fig_1"]
+    assert saved.solution.chat_history[0].user_message == "user 2"
+
+
+def test_autosave_after_chat_keeps_chat_applied_solution_fields(tmp_path) -> None:
+    repo = ProjectRepository(tmp_path)
+    repo.init_project("Exam", "Physics")
+    app = create_app(tmp_path, openai_key="k")
+    client = TestClient(app)
+    _seed_question(client, "q_chat_autosave", qtype="multiple_choice")
+
+    class _AI:
+        def chat_edit_question(self, question, user_message, attached_figure_ids=None):
+            updated = question.model_copy(deep=True)
+            updated.solution.answer_formula_md = "answer = 9"
+            updated.solution.answer_guidance = "{{answer}}"
+            updated.solution.mc_answer_specs = [
+                MCAnswerSpec(formula_md=f"answer = {idx}", rationale_md=f"r{idx}")
+                for idx in range(1, 5)
+            ]
+            return AIService.QuestionEditorResult(
+                assistant_message="Updated answer and distractors.",
+                question=updated,
+                warnings=[],
+                usage=AIUsageTotals(),
+                changed_fields=["answer_formula_md", "mc_answer_specs_json"],
+            )
+
+    app.state.ai = _AI()
+    original = repo.get_question("q_chat_autosave")
+    chat_resp = client.post(
+        "/questions/q_chat_autosave/ai/chat",
+        json={
+            "message": "Set the answer and distractors.",
+            "attached_figure_ids": [],
+            "editor_state": _editor_state_for_question(original),
+        },
+    )
+    assert chat_resp.status_code == 200
+    body = chat_resp.json()
+
+    autosave_resp = client.post(
+        "/questions/q_chat_autosave/autosave",
+        json={
+            "title": body["title"],
+            "question_type": body["question_type"],
+            "mc_options_guidance": body["mc_options_guidance"],
+            "question_template_md": body["question_template_md"],
+            "solution_parameters_yaml": body["solution_parameters_yaml"],
+            "answer_formula_md": body["answer_formula_md"],
+            "answer_guidance": body["answer_guidance"],
+            "distractor_functions_text": body["distractor_functions_text"],
+            "mc_answer_specs_json": body["mc_answer_specs_json"],
+            "choices_yaml": body["choices_yaml"],
+            "typed_solution_md": body["typed_solution_md"],
+            "typed_solution_status": body["typed_solution_status"],
+            "figures_json": body["figures_json"],
+            "chat_history_json": body["chat_history_json"],
+            "points": body["points"],
+        },
+    )
+    assert autosave_resp.status_code == 200
+    saved = repo.get_question("q_chat_autosave")
+    assert saved.solution.answer_formula_md == "answer = 9"
+    assert len(saved.solution.mc_answer_specs) == 4

--- a/tests/integration/test_autosave_and_ai_errors.py
+++ b/tests/integration/test_autosave_and_ai_errors.py
@@ -612,6 +612,48 @@ def test_ai_chat_updates_question_and_returns_payload(tmp_path) -> None:
     assert saved.solution.chat_history[0].user_message == "Please clean this up."
 
 
+def test_ai_chat_refreshes_rendered_answer_when_guidance_changes(tmp_path) -> None:
+    repo = ProjectRepository(tmp_path)
+    repo.init_project("Exam", "Physics")
+    app = create_app(tmp_path, openai_key="k")
+    client = TestClient(app)
+    _seed_question(client, "q_chat_answer")
+    seeded = repo.get_question("q_chat_answer")
+    seeded.solution.answer_formula_md = "answer = 9"
+    seeded.solution.answer_guidance = "Old answer: {{answer}}"
+    seeded.solution.last_computed_answer_md = "Old answer: 9"
+    repo.save_question(seeded)
+
+    class _AI:
+        def chat_edit_question(self, question, user_message, attached_figure_ids=None):
+            updated = question.model_copy(deep=True)
+            updated.solution.answer_guidance = "New answer: {{answer}}"
+            updated.solution.last_computed_answer_md = "Stale answer: 9"
+            return AIService.QuestionEditorResult(
+                assistant_message="Updated the answer text.",
+                question=updated,
+                warnings=[],
+                usage=AIUsageTotals(),
+                changed_fields=["answer_guidance"],
+            )
+
+    app.state.ai = _AI()
+    resp = client.post(
+        "/questions/q_chat_answer/ai/chat",
+        json={
+            "message": "Update the answer wording.",
+            "attached_figure_ids": [],
+            "editor_state": _editor_state_for_question(seeded),
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["rendered_answer_md"] == "New answer: 9"
+    saved = repo.get_question("q_chat_answer")
+    assert saved.solution.answer_guidance == "New answer: {{answer}}"
+    assert saved.solution.last_computed_answer_md == "New answer: 9"
+
+
 def test_ai_chat_uses_live_editor_state_and_persists_last_five_turns(tmp_path) -> None:
     repo = ProjectRepository(tmp_path)
     repo.init_project("Exam", "Physics")

--- a/tests/integration/test_browser_question_roundtrip.py
+++ b/tests/integration/test_browser_question_roundtrip.py
@@ -249,8 +249,18 @@ def test_browser_chat_response_updates_visible_mc_rows(tmp_path: Path) -> None:
                             { formula_md: "answer = x + 3", rationale_md: "off by three" },
                             { formula_md: "answer = x + 4", rationale_md: "off by four" }
                           ]),
-                          mc_preview_rows: [],
-                          mc_preview_choices: []
+                          mc_preview_rows: [
+                            { preview_md: "22.4", warning: "" },
+                            { preview_md: "23.4", warning: "" },
+                            { preview_md: "24.4", warning: "" },
+                            { preview_md: "25.4", warning: "" }
+                          ],
+                          mc_preview_choices: [
+                            { label: "A", content_md: "22.4", rationale: "" },
+                            { label: "B", content_md: "23.4", rationale: "" },
+                            { label: "C", content_md: "24.4", rationale: "" },
+                            { label: "D", content_md: "25.4", rationale: "" }
+                          ]
                         });
                     }""")
 
@@ -270,6 +280,10 @@ def test_browser_chat_response_updates_visible_mc_rows(tmp_path: Path) -> None:
                     page.locator("#mc_answer_4_rationale_md").input_value().strip()
                     == "off by four"
                 )
+                preview_height = page.locator("#mc_answer_1_preview").evaluate(
+                    "(el) => el.getBoundingClientRect().height"
+                )
+                assert preview_height < 40
             finally:
                 browser.close()
     finally:

--- a/tests/integration/test_browser_question_roundtrip.py
+++ b/tests/integration/test_browser_question_roundtrip.py
@@ -179,3 +179,103 @@ def test_browser_question_roundtrip(tmp_path: Path) -> None:
         except subprocess.TimeoutExpired:
             proc.kill()
             proc.wait(timeout=10)
+
+
+def test_browser_chat_response_updates_visible_mc_rows(tmp_path: Path) -> None:
+    pytest.importorskip("playwright.sync_api")
+    from playwright.sync_api import Error as PlaywrightError, sync_playwright
+
+    repo = ProjectRepository(tmp_path)
+    repo.init_project("MC Exam", "Physics 1")
+    port = _free_port()
+    base_url = f"http://127.0.0.1:{port}"
+
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "exam_helper.cli",
+            "serve",
+            str(tmp_path),
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    try:
+        _wait_for_server(base_url + "/", proc)
+        seed = httpx.post(
+            base_url + "/questions/save",
+            data={
+                "question_id": "q_browser_mc",
+                "title": "Browser MC Test",
+                "question_type": "multiple_choice",
+                "question_template_md": "What is the value?",
+                "solution_parameters_yaml": "x: 2",
+                "answer_formula_md": "answer = x",
+                "answer_guidance": "The answer is {{answer}}.",
+                "mc_options_guidance": "",
+                "distractor_functions_text": "",
+                "choices_yaml": "[]",
+                "typed_solution_md": "",
+                "typed_solution_status": "fresh",
+                "figures_json": "[]",
+                "points": 5,
+            },
+            follow_redirects=False,
+            timeout=5.0,
+        )
+        assert seed.status_code == 303
+        with sync_playwright() as p:
+            try:
+                browser = p.chromium.launch(headless=True)
+            except PlaywrightError as exc:
+                pytest.skip(f"Chromium is not available: {exc}")
+            try:
+                page = browser.new_page()
+                page.goto(base_url + "/questions/q_browser_mc/edit2")
+                page.wait_for_url(base_url + "/questions/q_browser_mc/edit2")
+
+                page.evaluate("""() => {
+                        setEditorValuesFromResponse({
+                          question_type: "multiple_choice",
+                          mc_answer_specs_json: JSON.stringify([
+                            { formula_md: "answer = x + 1", rationale_md: "off by one" },
+                            { formula_md: "answer = x + 2", rationale_md: "off by two" },
+                            { formula_md: "answer = x + 3", rationale_md: "off by three" },
+                            { formula_md: "answer = x + 4", rationale_md: "off by four" }
+                          ]),
+                          mc_preview_rows: [],
+                          mc_preview_choices: []
+                        });
+                    }""")
+
+                assert (
+                    page.locator("#mc_answer_1_formula_md").input_value().strip()
+                    == "answer = x + 1"
+                )
+                assert (
+                    page.locator("#mc_answer_1_rationale_md").input_value().strip()
+                    == "off by one"
+                )
+                assert (
+                    page.locator("#mc_answer_4_formula_md").input_value().strip()
+                    == "answer = x + 4"
+                )
+                assert (
+                    page.locator("#mc_answer_4_rationale_md").input_value().strip()
+                    == "off by four"
+                )
+            finally:
+                browser.close()
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=10)

--- a/tests/unit/test_ai_service.py
+++ b/tests/unit/test_ai_service.py
@@ -5,8 +5,9 @@ from exam_helper.models import Question
 
 
 class _FakeResponses:
-    def __init__(self, output_text: str):
-        self._output_text = output_text
+    def __init__(self, output_text: str | None = None, outputs: list | None = None):
+        self._output_text = output_text or ""
+        self._outputs = outputs or []
 
     def create(self, **kwargs):
         class R:
@@ -14,12 +15,46 @@ class _FakeResponses:
 
         r = R()
         r.output_text = self._output_text
+        r.output = self._outputs
+        r.id = "resp_1"
         return r
 
 
 class _FakeClient:
-    def __init__(self, output_text: str):
-        self.responses = _FakeResponses(output_text)
+    def __init__(self, output_text: str | None = None, outputs: list | None = None):
+        self.responses = _FakeResponses(output_text, outputs)
+
+
+class _SequencedResponses:
+    def __init__(self, steps: list[dict]):
+        self._steps = list(steps)
+
+    def create(self, **kwargs):
+        class R:
+            pass
+
+        if not self._steps:
+            raise AssertionError("Unexpected extra responses.create() call")
+        step = self._steps.pop(0)
+        r = R()
+        r.output_text = step.get("output_text", "")
+        r.output = step.get("output", [])
+        r.id = step.get("id", "resp_seq")
+        return r
+
+
+class _FakeToolCall:
+    type = "function_call"
+
+    def __init__(self, name: str, arguments: str, call_id: str = "call_1"):
+        self.name = name
+        self.arguments = arguments
+        self.call_id = call_id
+
+
+class _SequencedClient:
+    def __init__(self, steps: list[dict]):
+        self.responses = _SequencedResponses(steps)
 
 
 def test_ai_service_rewrite_parameterize(monkeypatch) -> None:
@@ -176,3 +211,53 @@ def test_generate_typed_solution_extracts_typed_solution_md_from_yaml_like_paylo
     out = svc.generate_typed_solution(q)
     assert "Step 1" in out.text
     assert "Final: 2.0 m/s" in out.text
+
+
+def test_ai_service_chat_edit_question_uses_tool_calls(monkeypatch) -> None:
+    from exam_helper import ai_service as mod
+
+    monkeypatch.setattr(
+        mod,
+        "OpenAI",
+        lambda api_key: _SequencedClient(
+            [
+                {
+                    "id": "resp_1",
+                    "output": [
+                        _FakeToolCall(
+                            "set_question_text",
+                            '{"question_template_md":"A cleaner prompt."}',
+                            call_id="call_q",
+                        ),
+                        _FakeToolCall(
+                            "set_answer_formula",
+                            '{"answer_formula_md":"x = 6\\nanswer = x"}',
+                            call_id="call_a",
+                        ),
+                        _FakeToolCall("compute_answer", "{}", call_id="call_c"),
+                    ],
+                },
+                {
+                    "output_text": (
+                        '{"assistant_message":"Updated the prompt and answer formula.",'
+                        '"warnings":["Validated the deterministic answer formula."]}'
+                    )
+                },
+            ]
+        ),
+    )
+    svc = AIService(api_key="k")
+    q = Question(id="q1", title="Original")
+    q.solution.parameters = {"x": 6}
+    q.solution.answer_guidance = "{{answer}}"
+    out = svc.chat_edit_question(q, "rewrite this")
+    assert out.assistant_message == "Updated the prompt and answer formula."
+    assert out.question.solution.question_template_md == "A cleaner prompt."
+    assert "answer = x" in out.question.solution.answer_formula_md
+    assert out.question.solution.last_computed_answer_md == "6"
+    assert out.changed_fields == [
+        "answer_formula_md",
+        "last_computed_answer_md",
+        "question_template_md",
+    ]
+    assert out.warnings == ["Validated the deterministic answer formula."]

--- a/tests/unit/test_ai_service.py
+++ b/tests/unit/test_ai_service.py
@@ -238,10 +238,13 @@ def test_ai_service_chat_edit_question_uses_tool_calls(monkeypatch) -> None:
                     ],
                 },
                 {
-                    "output_text": (
-                        '{"assistant_message":"Updated the prompt and answer formula.",'
-                        '"warnings":["Validated the deterministic answer formula."]}'
-                    )
+                    "output": [
+                        _FakeToolCall(
+                            "finish",
+                            '{"assistant_message":"Updated the prompt and answer formula.","warnings":["Validated the deterministic answer formula."]}',
+                            call_id="call_finish",
+                        )
+                    ]
                 },
             ]
         ),


### PR DESCRIPTION
Fixes #66

## Changes

- Added a chat assistant panel to the v2 question editor.
- Chat responses are validated server-side and merged back into the form state.
- Kept existing save/autosave and harness behavior intact.

## Validation:

- uv run --extra dev pytest -q
- uv run --extra dev black --check .

Risk:
- The chat flow is currently form-driven rather than fully arbitrary field mutation; hidden fields preserve the current editor state but the UI still exposes the existing question editor structure.