### PR TITLE
Rename chat editor route to /edit

### DIFF
--- a/src/exam_helper/app.py
+++ b/src/exam_helper/app.py
@@ -721,16 +721,16 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
 
     @app.get("/questions/{question_id}/edit", response_class=HTMLResponse)
     def edit_question(request: Request, question_id: str) -> HTMLResponse:
-        return RedirectResponse(f"/questions/{question_id}/edit2", status_code=303)
-
-    @app.get("/questions/{question_id}/edit2", response_class=HTMLResponse)
-    def edit_question_v2(request: Request, question_id: str) -> HTMLResponse:
         q = repo.get_question(question_id)
         return templates.TemplateResponse(
             request,
             "question_form_v2.html",
             _question_form_context(q),
         )
+
+    @app.get("/questions/{question_id}/edit2", response_class=HTMLResponse)
+    def edit_question_v2(request: Request, question_id: str) -> HTMLResponse:
+        return RedirectResponse(f"/questions/{question_id}/edit", status_code=303)
 
     @app.post("/questions/{question_id}/delete")
     def delete_question(question_id: str) -> RedirectResponse:

--- a/src/exam_helper/app.py
+++ b/src/exam_helper/app.py
@@ -728,10 +728,6 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
             _question_form_context(q),
         )
 
-    @app.get("/questions/{question_id}/edit2", response_class=HTMLResponse)
-    def edit_question_v2(request: Request, question_id: str) -> HTMLResponse:
-        return RedirectResponse(f"/questions/{question_id}/edit", status_code=303)
-
     @app.post("/questions/{question_id}/delete")
     def delete_question(question_id: str) -> RedirectResponse:
         question = repo.get_question(question_id)

--- a/src/exam_helper/templates/index.html
+++ b/src/exam_helper/templates/index.html
@@ -90,7 +90,7 @@
           <td>{{ q.question_type.value }}</td>
           <td>
             <div class="actions">
-              <a href="/questions/{{ q.id }}/edit2">Edit</a>
+              <a href="/questions/{{ q.id }}/edit">Edit</a>
               <form method="post" action="/questions/{{ q.id }}/delete" onsubmit="return confirm('Delete question {{ q.id }} from listings? The YAML file will remain on disk.');">
                 <button class="btn-link-danger" type="submit">Delete</button>
               </form>

--- a/tests/integration/test_app_ai_config_and_usage.py
+++ b/tests/integration/test_app_ai_config_and_usage.py
@@ -19,7 +19,7 @@ def test_home_shows_model_and_usage(tmp_path) -> None:
     assert "gpt-5.2" in resp.text
 
 
-def test_question_editor_has_new_workflow_hooks(tmp_path) -> None:
+def test_question_editor_has_chat_workflow_hooks(tmp_path) -> None:
     repo = ProjectRepository(tmp_path)
     repo.init_project("Exam", "Physics")
     app = create_app(tmp_path, openai_key=None)
@@ -39,28 +39,26 @@ def test_question_editor_has_new_workflow_hooks(tmp_path) -> None:
             "points": 5,
         },
     )
-    resp = client.get("/questions/q_edit/edit2")
+    resp = client.get("/questions/q_edit/edit")
     assert resp.status_code == 200
-    assert "Edit Question" in resp.text
-    assert 'id="btn_rewrite"' not in resp.text
-    assert 'id="btn_generate_answer"' not in resp.text
-    assert 'id="mc_options_guidance"' in resp.text
-    assert 'id="btn_generate_typed_solution"' not in resp.text
-    assert "function setAiBusy(isBusy)" not in resp.text
-    assert "await autosaveNow({ allowWhenBusy: true });" not in resp.text
-    assert "mc_options_guidance: mcOptionsGuidanceEl.value" in resp.text
-    assert 'id="mc_answer_specs_json"' in resp.text
-    assert 'id="mc_answer_1_formula_md"' in resp.text
-    assert "Multiple Choice Distractors" in resp.text
-    assert "Correct Answer (auto-fed)" not in resp.text
-    assert "AI request in progress; editing is temporarily disabled." not in resp.text
+    assert 'id="chat_thread"' in resp.text
+    assert 'id="chat_message"' in resp.text
+    assert 'id="btn_send_chat"' in resp.text
+    assert "formula-preview--compact" in resp.text
+    assert "OpenAI chat is enabled." not in resp.text
+    assert "Configure an OpenAI key to use chat." not in resp.text
+    assert "No API key configured" in resp.text
+    assert 'title="Shift+Enter to send"' in resp.text
+    assert 'title="No API key configured."' in resp.text
+    assert "setChatBusy(true)" in resp.text
+    assert 'event.key === "Enter" && event.shiftKey' in resp.text
 
-    redirect = client.get("/questions/q_edit/edit", follow_redirects=False)
+    redirect = client.get("/questions/q_edit/edit2", follow_redirects=False)
     assert redirect.status_code == 303
-    assert redirect.headers["location"] == "/questions/q_edit/edit2"
+    assert redirect.headers["location"] == "/questions/q_edit/edit"
 
 
-def test_question_editor_v2_has_chat_hooks(tmp_path) -> None:
+def test_question_editor_legacy_path_redirects_to_edit(tmp_path) -> None:
     repo = ProjectRepository(tmp_path)
     repo.init_project("Exam", "Physics")
     app = create_app(tmp_path, openai_key=None)
@@ -80,19 +78,9 @@ def test_question_editor_v2_has_chat_hooks(tmp_path) -> None:
             "points": 5,
         },
     )
-    resp = client.get("/questions/q_edit2/edit2")
-    assert resp.status_code == 200
-    assert 'id="chat_thread"' in resp.text
-    assert 'id="chat_message"' in resp.text
-    assert 'id="btn_send_chat"' in resp.text
-    assert "formula-preview--compact" in resp.text
-    assert "OpenAI chat is enabled." not in resp.text
-    assert "Configure an OpenAI key to use chat." not in resp.text
-    assert "No API key configured" in resp.text
-    assert 'title="Shift+Enter to send"' in resp.text
-    assert 'title="No API key configured."' in resp.text
-    assert "setChatBusy(true)" in resp.text
-    assert 'event.key === "Enter" && event.shiftKey' in resp.text
+    resp = client.get("/questions/q_edit2/edit2", follow_redirects=False)
+    assert resp.status_code == 303
+    assert resp.headers["location"] == "/questions/q_edit2/edit"
 
 
 def test_usage_totals_accumulate_and_reset(tmp_path) -> None:

--- a/tests/integration/test_app_ai_config_and_usage.py
+++ b/tests/integration/test_app_ai_config_and_usage.py
@@ -53,12 +53,8 @@ def test_question_editor_has_chat_workflow_hooks(tmp_path) -> None:
     assert "setChatBusy(true)" in resp.text
     assert 'event.key === "Enter" && event.shiftKey' in resp.text
 
-    redirect = client.get("/questions/q_edit/edit2", follow_redirects=False)
-    assert redirect.status_code == 303
-    assert redirect.headers["location"] == "/questions/q_edit/edit"
 
-
-def test_question_editor_legacy_path_redirects_to_edit(tmp_path) -> None:
+def test_question_editor_rendering_is_stable(tmp_path) -> None:
     repo = ProjectRepository(tmp_path)
     repo.init_project("Exam", "Physics")
     app = create_app(tmp_path, openai_key=None)
@@ -66,7 +62,7 @@ def test_question_editor_legacy_path_redirects_to_edit(tmp_path) -> None:
     client.post(
         "/questions/save",
         data={
-            "question_id": "q_edit2",
+            "question_id": "q_chat",
             "title": "T",
             "question_type": "free_response",
             "prompt_md": "P",
@@ -78,9 +74,9 @@ def test_question_editor_legacy_path_redirects_to_edit(tmp_path) -> None:
             "points": 5,
         },
     )
-    resp = client.get("/questions/q_edit2/edit2", follow_redirects=False)
-    assert resp.status_code == 303
-    assert resp.headers["location"] == "/questions/q_edit2/edit"
+    resp = client.get("/questions/q_chat/edit")
+    assert resp.status_code == 200
+    assert 'id="chat_thread"' in resp.text
 
 
 def test_usage_totals_accumulate_and_reset(tmp_path) -> None:

--- a/tests/integration/test_app_question_save.py
+++ b/tests/integration/test_app_question_save.py
@@ -146,7 +146,7 @@ def test_new_question_2_page_contains_simplified_editor(tmp_path) -> None:
     assert 'id="btn_generate_answer"' not in html
 
 
-def test_edit2_existing_question_save_preserves_legacy_fields(tmp_path) -> None:
+def test_edit_existing_question_save_preserves_legacy_fields(tmp_path) -> None:
     repo = ProjectRepository(tmp_path)
     repo.init_project("Exam", "Physics")
     question_path = tmp_path / "questions" / "legacy-edit2.yaml"
@@ -174,7 +174,7 @@ def test_edit2_existing_question_save_preserves_legacy_fields(tmp_path) -> None:
     app = create_app(tmp_path, openai_key=None)
     client = TestClient(app)
 
-    edit_resp = client.get("/questions/legacy-edit2/edit2")
+    edit_resp = client.get("/questions/legacy-edit2/edit")
     assert edit_resp.status_code == 200
     edit_html = edit_resp.text
     assert 'id="figures_json"' in edit_html
@@ -322,7 +322,7 @@ def test_new_question_id_skips_soft_deleted_ids(tmp_path) -> None:
     assert 'id="question_id" value="q2"' in new_page.text
 
 
-def test_home_shows_edit2_and_new_question_2_links(tmp_path) -> None:
+def test_home_shows_edit_and_new_question_2_links(tmp_path) -> None:
     repo = ProjectRepository(tmp_path)
     repo.init_project("Exam", "Physics")
     app = create_app(tmp_path, openai_key=None)
@@ -347,9 +347,8 @@ def test_home_shows_edit2_and_new_question_2_links(tmp_path) -> None:
     home = client.get("/")
     assert home.status_code == 200
     assert 'href="/questions/new2"' in home.text
-    assert 'href="/questions/q1/edit2"' in home.text
+    assert 'href="/questions/q1/edit"' in home.text
     assert 'href="/questions/new"' not in home.text
-    assert 'href="/questions/q1/edit"' not in home.text
 
 
 def test_save_persists_dollar_math_delimiters(tmp_path) -> None:

--- a/tests/integration/test_app_question_save.py
+++ b/tests/integration/test_app_question_save.py
@@ -149,11 +149,11 @@ def test_new_question_2_page_contains_simplified_editor(tmp_path) -> None:
 def test_edit_existing_question_save_preserves_legacy_fields(tmp_path) -> None:
     repo = ProjectRepository(tmp_path)
     repo.init_project("Exam", "Physics")
-    question_path = tmp_path / "questions" / "legacy-edit2.yaml"
+    question_path = tmp_path / "questions" / "legacy-editor.yaml"
     question_path.write_text(
         yaml.safe_dump(
             {
-                "id": "legacy-edit2",
+                "id": "legacy-editor",
                 "title": "Old title",
                 "question_type": "free_response",
                 "prompt_md": "Old prompt",
@@ -174,7 +174,7 @@ def test_edit_existing_question_save_preserves_legacy_fields(tmp_path) -> None:
     app = create_app(tmp_path, openai_key=None)
     client = TestClient(app)
 
-    edit_resp = client.get("/questions/legacy-edit2/edit")
+    edit_resp = client.get("/questions/legacy-editor/edit")
     assert edit_resp.status_code == 200
     edit_html = edit_resp.text
     assert 'id="figures_json"' in edit_html
@@ -189,7 +189,7 @@ def test_edit_existing_question_save_preserves_legacy_fields(tmp_path) -> None:
     save_resp = client.post(
         "/questions/save",
         data={
-            "question_id": "legacy-edit2",
+            "question_id": "legacy-editor",
             "title": "Updated title",
             "question_type": "free_response",
             "choices_yaml": "[]",
@@ -285,7 +285,6 @@ def test_soft_delete_hides_question_but_keeps_yaml_on_disk(tmp_path) -> None:
     home = client.get("/")
     assert home.status_code == 200
     assert "/questions/q1/edit" not in home.text
-    assert "/questions/q1/edit2" not in home.text
 
     question_file = tmp_path / "questions" / "q1.yaml"
     assert question_file.exists()

--- a/tests/integration/test_browser_question_roundtrip.py
+++ b/tests/integration/test_browser_question_roundtrip.py
@@ -99,7 +99,7 @@ def test_browser_question_roundtrip(tmp_path: Path) -> None:
 
                 page.goto(base_url + "/")
                 page.get_by_role("link", name="Edit").click()
-                page.wait_for_url(base_url + "/questions/q_browser/edit2")
+                page.wait_for_url(base_url + "/questions/q_browser/edit")
 
                 assert page.locator("#question_id").input_value() == "q_browser"
                 assert page.locator("#title").input_value() == "Browser Test"
@@ -138,7 +138,7 @@ def test_browser_question_roundtrip(tmp_path: Path) -> None:
                 page.wait_for_url(base_url + "/")
 
                 page.get_by_role("link", name="Edit").click()
-                page.wait_for_url(base_url + "/questions/q_browser/edit2")
+                page.wait_for_url(base_url + "/questions/q_browser/edit")
 
                 assert page.locator("#question_id").input_value() == "q_browser"
                 assert page.locator("#title").input_value() == "Browser Test Updated"
@@ -237,8 +237,8 @@ def test_browser_chat_response_updates_visible_mc_rows(tmp_path: Path) -> None:
                 pytest.skip(f"Chromium is not available: {exc}")
             try:
                 page = browser.new_page()
-                page.goto(base_url + "/questions/q_browser_mc/edit2")
-                page.wait_for_url(base_url + "/questions/q_browser_mc/edit2")
+                page.goto(base_url + "/questions/q_browser_mc/edit")
+                page.wait_for_url(base_url + "/questions/q_browser_mc/edit")
 
                 page.evaluate("""() => {
                         setEditorValuesFromResponse({


### PR DESCRIPTION
Fixes #78

- Make `/questions/{id}/edit` the canonical chat editor route
- Remove the legacy alternate route entirely
- Update home-page links, integration tests, and browser tests to use `/edit`

Validation:
- `uv run --extra dev pytest -q`
- `uv run --extra dev black --check .`

Remaining risk: none beyond the standard risk of route renames; the app now exposes a single editor URL.