### PR TITLE
Fix natural question ordering

### DIFF
--- a/src/exam_helper/repository.py
+++ b/src/exam_helper/repository.py
@@ -1,10 +1,21 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import yaml
 
 from exam_helper.models import AIUsageTotals, ProjectConfig, Question
+
+
+def _natural_sort_key(text: str) -> list[object]:
+    parts = re.split(r"(\d+)", text.casefold())
+    key: list[object] = []
+    for part in parts:
+        if not part:
+            continue
+        key.append(int(part) if part.isdigit() else part)
+    return key
 
 
 class ProjectRepository:
@@ -39,7 +50,10 @@ class ProjectRepository:
 
     def list_questions(self, include_deleted: bool = False) -> list[Question]:
         items: list[Question] = []
-        for q_file in sorted(self.questions_dir.glob("*.yaml")):
+        for q_file in sorted(
+            self.questions_dir.glob("*.yaml"),
+            key=lambda path: _natural_sort_key(path.stem),
+        ):
             raw = yaml.safe_load(q_file.read_text(encoding="utf-8"))
             question = Question.model_validate(raw)
             if question.is_deleted and not include_deleted:
@@ -69,7 +83,10 @@ class ProjectRepository:
             self.load_project()
         except Exception as ex:
             errors.append(f"project.yaml invalid: {ex}")
-        for q_file in sorted(self.questions_dir.glob("*.yaml")):
+        for q_file in sorted(
+            self.questions_dir.glob("*.yaml"),
+            key=lambda path: _natural_sort_key(path.stem),
+        ):
             try:
                 raw = yaml.safe_load(q_file.read_text(encoding="utf-8"))
                 question = Question.model_validate(raw)

--- a/tests/unit/test_models_repository.py
+++ b/tests/unit/test_models_repository.py
@@ -93,3 +93,13 @@ def test_list_questions_excludes_soft_deleted_by_default(tmp_path: Path) -> None
 
     all_questions = repo.list_questions(include_deleted=True)
     assert [q.id for q in all_questions] == ["q_active", "q_deleted"]
+
+
+def test_list_questions_uses_natural_question_order(tmp_path: Path) -> None:
+    repo = ProjectRepository(tmp_path)
+    repo.init_project("Exam", "Physics")
+    repo.save_question(Question(id="q1", title="First"))
+    repo.save_question(Question(id="q10", title="Tenth"))
+    repo.save_question(Question(id="q2", title="Second"))
+
+    assert [q.id for q in repo.list_questions()] == ["q1", "q2", "q10"]


### PR DESCRIPTION
Fixes #58

- Sort question files with a natural numeric key so `q2` appears before `q10`.
- Apply the same order in repository listing and validation traversal.
- Add a regression test for `list_questions()` ordering.

Validation:
- `uv run --extra dev pytest -q`
- `uv run --extra dev black --check .`

Remaining risk:
- Ordering is still based on question IDs, so non-numeric naming schemes will follow natural string order.