### PR TITLE
Tighten extracted parameters to numeric scalars

### DIFF
--- a/src/exam_helper/ai_service.py
+++ b/src/exam_helper/ai_service.py
@@ -19,6 +19,7 @@ from exam_helper.models import (
     Question,
     QuestionType,
 )
+from exam_helper.parameter_utils import coerce_numeric_scalar
 from exam_helper.prompt_catalog import PromptBundle, PromptCatalog
 from exam_helper.solution_runtime import (
     SolutionRuntimeError,
@@ -895,46 +896,6 @@ class AIService:
             f"string/list, got {type(raw_params).__name__}."
         )
 
-    @staticmethod
-    def _coerce_numeric_scalar(value: Any) -> Any:
-        if isinstance(value, bool):
-            return value
-        if isinstance(value, (int, float)):
-            return value
-        if not isinstance(value, str):
-            return value
-        text = value.strip()
-        if not text:
-            return value
-
-        if re.fullmatch(r"[+-]?\d+", text):
-            try:
-                return int(text)
-            except Exception:
-                return value
-
-        if re.fullmatch(r"[+-]?(?:\d+\.\d*|\d*\.\d+)(?:[eE][+-]?\d+)?", text):
-            try:
-                return float(text)
-            except Exception:
-                return value
-
-        frac_match = re.fullmatch(r"([+-]?\d+)\s*/\s*([+-]?\d+)", text)
-        if frac_match:
-            denom = int(frac_match.group(2))
-            if denom != 0:
-                return int(frac_match.group(1)) / denom
-            return value
-
-        latex_frac_match = re.fullmatch(
-            r"\\(?:t?frac)\{([+-]?\d+)\}\{([+-]?\d+)\}", text
-        )
-        if latex_frac_match:
-            denom = int(latex_frac_match.group(2))
-            if denom != 0:
-                return int(latex_frac_match.group(1)) / denom
-        return value
-
     @classmethod
     def _normalize_rewrite_parameters(
         cls,
@@ -974,7 +935,7 @@ class AIService:
                         rewritten_template,
                     )
                 continue
-            filtered[key_clean] = cls._coerce_numeric_scalar(value)
+            filtered[key_clean] = coerce_numeric_scalar(value, strict=True)
 
         return filtered, rewritten_template
 

--- a/src/exam_helper/app.py
+++ b/src/exam_helper/app.py
@@ -26,6 +26,7 @@ from exam_helper.models import (
     Question,
     QuestionType,
 )
+from exam_helper.parameter_utils import coerce_numeric_scalar
 from exam_helper.normalization import normalize_markdown_math_delimiters
 from exam_helper.repository import ProjectRepository
 from exam_helper.solution_runtime import (
@@ -106,6 +107,15 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
 
     def dump_parameters_yaml(params: dict[str, Any]) -> str:
         return yaml.safe_dump(params or {}, sort_keys=False).strip()
+
+    def validate_numeric_parameters(params: dict[str, Any]) -> dict[str, Any]:
+        validated: dict[str, Any] = {}
+        for key, value in (params or {}).items():
+            key_clean = str(key).strip()
+            if not key_clean:
+                continue
+            validated[key_clean] = coerce_numeric_scalar(value, strict=True)
+        return validated
 
     def parse_distractor_functions_text(raw_text: str) -> list[DistractorFunction]:
         text = (raw_text or "").strip()
@@ -937,11 +947,12 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
             q = repo.get_question(question_id)
             result = app.state.ai.rewrite_parameterize(q)
             repo.add_ai_usage(result.usage)
+            parameters = validate_numeric_parameters(result.parameters)
             normalized_template = normalize_markdown_math_delimiters(
                 result.question_template_md
             )
             rendered_prompt = render_template_from_values(
-                normalized_template, result.parameters
+                normalized_template, parameters
             )
             title = q.title.strip() or result.title.strip()
             return {
@@ -950,7 +961,7 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
                 "rendered_prompt_md": normalize_markdown_math_delimiters(
                     rendered_prompt
                 ),
-                "solution_parameters_yaml": dump_parameters_yaml(result.parameters),
+                "solution_parameters_yaml": dump_parameters_yaml(parameters),
                 "title": title,
             }
         except Exception as ex:

--- a/src/exam_helper/parameter_utils.py
+++ b/src/exam_helper/parameter_utils.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from typing import Any
+import re
+
+
+def coerce_numeric_scalar(value: Any, *, strict: bool = False) -> Any:
+    if isinstance(value, bool):
+        if strict:
+            raise ValueError("parameter values must be numeric scalars.")
+        return value
+    if isinstance(value, (int, float)):
+        return value
+    if not isinstance(value, str):
+        if strict:
+            raise ValueError("parameter values must be numeric scalars.")
+        return value
+    text = value.strip()
+    if not text:
+        if strict:
+            raise ValueError("parameter values must be numeric scalars.")
+        return value
+
+    if re.fullmatch(r"[+-]?\d+", text):
+        try:
+            return int(text)
+        except Exception:
+            if strict:
+                raise ValueError("parameter values must be numeric scalars.")
+            return value
+
+    if re.fullmatch(r"[+-]?(?:\d+\.\d*|\d*\.\d+)(?:[eE][+-]?\d+)?", text):
+        try:
+            return float(text)
+        except Exception:
+            if strict:
+                raise ValueError("parameter values must be numeric scalars.")
+            return value
+
+    frac_match = re.fullmatch(r"([+-]?\d+)\s*/\s*([+-]?\d+)", text)
+    if frac_match:
+        denom = int(frac_match.group(2))
+        if denom != 0:
+            return int(frac_match.group(1)) / denom
+        if strict:
+            raise ValueError("parameter values must be numeric scalars.")
+        return value
+
+    latex_frac_match = re.fullmatch(r"\\(?:t?frac)\{([+-]?\d+)\}\{([+-]?\d+)\}", text)
+    if latex_frac_match:
+        denom = int(latex_frac_match.group(2))
+        if denom != 0:
+            return int(latex_frac_match.group(1)) / denom
+    if strict:
+        raise ValueError("parameter values must be numeric scalars.")
+    return value

--- a/src/exam_helper/prompt_templates.yaml
+++ b/src/exam_helper/prompt_templates.yaml
@@ -7,7 +7,7 @@ actions:
       - title (required if current title is empty)
 
       Rewrite the question as a reusable Question Template (Markdown).
-      Extract variable values into Template Parameters (YAML-compatible key/value mapping) using numeric scalars whenever possible.
+      Extract variable values into Template Parameters (YAML-compatible key/value mapping) using numeric scalars only.
       Use {{parameter_name}} references in question_template_md.
       Do not include figure/image references (for example figure_ref, fig_ref, figure_id) in parameters.
       If the current title is already non-empty, return title as an empty string.

--- a/tests/integration/test_autosave_and_ai_errors.py
+++ b/tests/integration/test_autosave_and_ai_errors.py
@@ -173,6 +173,32 @@ def test_ai_rewrite_and_parameterize_does_not_fallback_title_from_prompt(
     assert data["title"] == ""
 
 
+def test_ai_rewrite_and_parameterize_rejects_non_numeric_parameters(
+    tmp_path,
+) -> None:
+    repo = ProjectRepository(tmp_path)
+    repo.init_project("Exam", "Physics")
+    app = create_app(tmp_path, openai_key="k")
+    client = TestClient(app)
+    _seed_question(client, "q_rewrite_bad")
+
+    class _AI:
+        def rewrite_parameterize(self, question):
+            return AIService.RewriteResult(
+                question_template_md="A cart has speed {{v}} m/s.",
+                parameters={"v": "10 m/s"},
+                title="Cart speed",
+                usage=AIUsageTotals(),
+            )
+
+    app.state.ai = _AI()
+    resp = client.post("/questions/q_rewrite_bad/ai/rewrite-and-parameterize")
+    assert resp.status_code == 422
+    payload = resp.json()
+    assert payload["ok"] is False
+    assert "numeric scalars" in payload["error"]
+
+
 def test_harness_run_returns_422_for_collisions(tmp_path) -> None:
     repo = ProjectRepository(tmp_path)
     repo.init_project("Exam", "Physics")

--- a/tests/unit/test_ai_service.py
+++ b/tests/unit/test_ai_service.py
@@ -129,6 +129,24 @@ def test_ai_service_rewrite_parameterize_coerces_list_parameters(monkeypatch) ->
     assert "figure_ref" not in out.parameters
 
 
+def test_ai_service_rewrite_parameterize_rejects_non_numeric_parameters(
+    monkeypatch,
+) -> None:
+    from exam_helper import ai_service as mod
+
+    payload = """{"question_template_md":"A car moves at {{v}} m/s","parameters":{"v":"10 m/s"},"title":""}"""
+    monkeypatch.setattr(mod, "OpenAI", lambda api_key: _FakeClient(payload))
+    svc = AIService(api_key="k")
+    q = Question(id="q1", title="", prompt_md="old")
+
+    try:
+        svc.rewrite_parameterize(q)
+    except ValueError as ex:
+        assert "numeric scalars" in str(ex)
+    else:
+        raise AssertionError("rewrite_parameterize should reject non-numeric values")
+
+
 def test_ai_service_rewrite_parameterize_normalizes_fraction_and_drops_figure_ref(
     monkeypatch,
 ) -> None:


### PR DESCRIPTION
Fixes #54

- Validate AI rewrite parameters as numeric scalars before rendering or returning them.
- Share the numeric coercion helper between AI rewrite handling and the rewrite response boundary.
- Update the rewrite prompt to say numeric scalars only and add tests for rejection of non-numeric values.

Validation:
- uv run --extra dev pytest -q tests/unit/test_ai_service.py tests/integration/test_autosave_and_ai_errors.py tests/integration/test_app_question_save.py tests/unit/test_prompt_catalog.py
- uv run --extra dev pytest -q
- uv run --extra dev black --check .

Remaining risk:
- Manual question YAML still accepts legacy nonnumeric values, but AI-generated rewrite output is now constrained to numeric parameters only.