### PR TITLE
Default new questions to multiple choice

### DIFF
--- a/src/exam_helper/app.py
+++ b/src/exam_helper/app.py
@@ -41,7 +41,7 @@ from exam_helper.validation import validate_question
 
 class AutosavePayload(BaseModel):
     title: str = ""
-    question_type: str = "free_response"
+    question_type: str = "multiple_choice"
     mc_options_guidance: str = ""
     question_template_md: str = ""
     solution_parameters_yaml: str = "{}"
@@ -474,7 +474,7 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
         question_type_value = str(
             values.get(
                 "question_type",
-                existing.question_type.value if existing else "free_response",
+                existing.question_type.value if existing else "multiple_choice",
             )
         )
         mc_preview = _compute_mc_preview(
@@ -551,7 +551,7 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
             "question_type": (
                 question.question_type.value
                 if question
-                else QuestionType.free_response.value
+                else QuestionType.multiple_choice.value
             ),
             "mc_options_guidance": question.mc_options_guidance if question else "",
             "question_template_md": (
@@ -750,7 +750,7 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
         question_id: str = Form(...),
         title: str = Form(""),
         points: int = Form(5),
-        question_type: str = Form("free_response"),
+        question_type: str = Form("multiple_choice"),
         mc_options_guidance: str = Form(""),
         question_template_md: str = Form(""),
         mc_answer_specs_json: str = Form("[]"),

--- a/src/exam_helper/models.py
+++ b/src/exam_helper/models.py
@@ -89,7 +89,7 @@ class Question(BaseModel):
     difficulty: int = 3
     points: int = 5
     is_deleted: bool = False
-    question_type: QuestionType = QuestionType.free_response
+    question_type: QuestionType = QuestionType.multiple_choice
     mc_options_guidance: str = ""
     figures: list[FigureData] = Field(default_factory=list)
     choices: list[MCChoice] = Field(default_factory=list)

--- a/src/exam_helper/templates/question_form_v2.html
+++ b/src/exam_helper/templates/question_form_v2.html
@@ -309,7 +309,7 @@
             <label>Type</label>
             <select name="question_type" id="question_type">
               <option value="free_response" {% if question and question.question_type.value=="free_response" %}selected{% endif %}>Free Response</option>
-              <option value="multiple_choice" {% if question and question.question_type.value=="multiple_choice" %}selected{% endif %}>Multiple Choice</option>
+              <option value="multiple_choice" {% if not question or question.question_type.value=="multiple_choice" %}selected{% endif %}>Multiple Choice</option>
             </select>
           </div>
           <div class="card">

--- a/tests/integration/test_app_question_save.py
+++ b/tests/integration/test_app_question_save.py
@@ -144,6 +144,8 @@ def test_new_question_2_page_contains_simplified_editor(tmp_path) -> None:
     assert 'id="rendered_answer_md"' in html
     assert 'id="btn_rewrite"' not in html
     assert 'id="btn_generate_answer"' not in html
+    assert '<option value="multiple_choice" selected>' in html
+    assert '<option value="free_response" selected>' not in html
 
 
 def test_edit_existing_question_save_preserves_legacy_fields(tmp_path) -> None:

--- a/tests/unit/test_models_repository.py
+++ b/tests/unit/test_models_repository.py
@@ -41,6 +41,7 @@ def test_question_defaults_allow_empty_title() -> None:
     q = Question(id="q2", prompt_md="p")
     assert q.title == ""
     assert q.points == 5
+    assert q.question_type == QuestionType.multiple_choice
 
 
 def test_multiple_choice_allows_partial_choices_during_authoring() -> None:

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import yaml
 
-from exam_helper.models import Question
+from exam_helper.models import Question, QuestionType
 from exam_helper.repository import ProjectRepository
 from exam_helper.validation import validate_project
 
@@ -16,6 +16,7 @@ def test_validate_project_with_solution_code(tmp_path: Path) -> None:
         id="q1",
         title="t",
         prompt_md="p",
+        question_type=QuestionType.free_response,
         solution={
             "answer_formula_md": "answer = 'ok'",
             "parameters": {},


### PR DESCRIPTION
Fixes #48

- Default new questions to multiple choice in the model, editor form, and save/autosave fallbacks.
- Added regression coverage for the default question type and the new-question page rendering.
- Validated with `uv run --extra dev pytest -q` and `uv run --extra dev black --check .`.