### PR TITLE
Collapse chat assistant panel by default

### DIFF
--- a/src/exam_helper/templates/question_form_v2.html
+++ b/src/exam_helper/templates/question_form_v2.html
@@ -213,6 +213,30 @@
         display: grid;
         gap: 0.85rem;
       }
+      .chat-panel > summary {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        cursor: pointer;
+        font-weight: 700;
+        list-style: none;
+      }
+      .chat-panel > summary::-webkit-details-marker {
+        display: none;
+      }
+      .chat-panel > summary::before {
+        content: "▸";
+        color: var(--accent);
+        font-size: 1rem;
+        line-height: 1;
+      }
+      .chat-panel[open] > summary::before {
+        content: "▾";
+      }
+      .chat-panel-body {
+        display: grid;
+        gap: 0.85rem;
+      }
       .chat-panel.is-busy {
         opacity: 0.78;
       }
@@ -323,30 +347,32 @@
           <input name="title" id="title" value="{{ question.title if question else '' }}" />
         </div>
 
-        <div class="card chat-panel" aria-disabled="{{ 'false' if ai_enabled else 'true' }}" title="{{ 'No API key configured' if not ai_enabled else 'Chat Assistant' }}">
-          <label for="chat_message">Chat Assistant</label>
-          <p class="hint">{{ 'Ask for a rewrite, a cleanup pass, a distractor tweak, or a question-specific edit. Enter adds a newline. Use Shift+Enter to send.' if ai_enabled else 'Chat is disabled until an OpenAI key is configured.' }}</p>
-          <div id="chat_thread" class="chat-log" aria-live="polite"></div>
-          <div class="chat-input-row">
-            <textarea
-              id="chat_message"
-              placeholder="e.g. Please turn this rough prompt into a cleaner exam question."
-              title="{{ 'Enter adds a newline. Use Shift+Enter to send.' if ai_enabled else 'No API key configured.' }}"
-              {% if not ai_enabled %}disabled{% endif %}
-            ></textarea>
-            <div id="chat_attachments" class="chat-attachments"></div>
-            <div class="actions">
-              <button
-                type="button"
-                class="btn"
-                id="btn_send_chat"
-                title="Shift+Enter to send"
+        <details class="card chat-panel" aria-disabled="{{ 'false' if ai_enabled else 'true' }}" title="{{ 'No API key configured' if not ai_enabled else 'Chat Assistant' }}">
+          <summary>Chat Assistant</summary>
+          <div class="chat-panel-body">
+            <p class="hint">{{ 'Ask for a rewrite, a cleanup pass, a distractor tweak, or a question-specific edit. Enter adds a newline. Use Shift+Enter to send.' if ai_enabled else 'Chat is disabled until an OpenAI key is configured.' }}</p>
+            <div id="chat_thread" class="chat-log" aria-live="polite"></div>
+            <div class="chat-input-row">
+              <textarea
+                id="chat_message"
+                placeholder="e.g. Please turn this rough prompt into a cleaner exam question."
+                title="{{ 'Enter adds a newline. Use Shift+Enter to send.' if ai_enabled else 'No API key configured.' }}"
                 {% if not ai_enabled %}disabled{% endif %}
-              >Send</button>
-              <span id="chat_status" class="status"></span>
+              ></textarea>
+              <div id="chat_attachments" class="chat-attachments"></div>
+              <div class="actions">
+                <button
+                  type="button"
+                  class="btn"
+                  id="btn_send_chat"
+                  title="Shift+Enter to send"
+                  {% if not ai_enabled %}disabled{% endif %}
+                >Send</button>
+                <span id="chat_status" class="status"></span>
+              </div>
             </div>
           </div>
-        </div>
+        </details>
 
         <div class="row">
           <div class="card">

--- a/tests/integration/test_app_ai_config_and_usage.py
+++ b/tests/integration/test_app_ai_config_and_usage.py
@@ -41,6 +41,8 @@ def test_question_editor_has_chat_workflow_hooks(tmp_path) -> None:
     )
     resp = client.get("/questions/q_edit/edit")
     assert resp.status_code == 200
+    assert '<details class="card chat-panel"' in resp.text
+    assert "<summary>Chat Assistant</summary>" in resp.text
     assert 'id="chat_thread"' in resp.text
     assert 'id="chat_message"' in resp.text
     assert 'id="btn_send_chat"' in resp.text


### PR DESCRIPTION
Fixes #79

- Convert the chat assistant block into a native disclosure panel so it starts collapsed.
- Add regression coverage that verifies the editor renders the chat panel as a `<details>` element with a summary.
- Validate with `uv run --extra dev pytest -q tests/integration/test_app_ai_config_and_usage.py tests/integration/test_app_question_save.py`, `uv run --extra dev pytest -q`, and `uv run --extra dev black --check .`.

Remaining risk: browser support for `<details>` is broad, but the exact disclosure triangle appearance is left to native rendering.