### PR TITLE
Refactor editor state round trip

### DIFF
--- a/src/exam_helper/app.py
+++ b/src/exam_helper/app.py
@@ -39,7 +39,7 @@ from exam_helper.solution_runtime import (
 from exam_helper.validation import validate_question
 
 
-class AutosavePayload(BaseModel):
+class QuestionEditorState(BaseModel):
     title: str = ""
     question_type: str = "multiple_choice"
     mc_options_guidance: str = ""
@@ -57,10 +57,13 @@ class AutosavePayload(BaseModel):
     points: int = 5
 
 
+AutosavePayload = QuestionEditorState
+
+
 class ChatPayload(BaseModel):
     message: str = ""
     attached_figure_ids: list[str] = []
-    editor_state: AutosavePayload
+    editor_state: QuestionEditorState
 
 
 def _sanitize_docx_filename_stem(project_name: str) -> str:
@@ -406,12 +409,46 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
                 for turn in (question.solution.chat_history[-5:] if question else [])
             ]
         )
+        editor_state = QuestionEditorState(
+            title=question.title if question else "",
+            points=question.points if question else 5,
+            question_type=(
+                question.question_type.value
+                if question
+                else QuestionType.multiple_choice.value
+            ),
+            mc_options_guidance=question.mc_options_guidance if question else "",
+            question_template_md=(
+                question.solution.question_template_md
+                if question
+                else "The length of the rod is {{dummy}} $m$."
+            ),
+            solution_parameters_yaml=(
+                solution_parameters_yaml if question else "dummy: 5"
+            ),
+            answer_formula_md=question.solution.answer_formula_md if question else "",
+            answer_guidance=question.solution.answer_guidance if question else "",
+            distractor_functions_text=distractor_functions_text,
+            mc_answer_specs_json=dump_mc_answer_specs_json(mc_answer_specs),
+            choices_yaml=(
+                dump_choices_yaml(question.choices)
+                if question and question.choices
+                else default_mc_choices_yaml()
+            ),
+            typed_solution_md=(question.solution.typed_solution_md if question else ""),
+            typed_solution_status=(
+                question.solution.typed_solution_status if question else "missing"
+            ),
+            figures_json=figures_json,
+            chat_history_json=chat_history_json,
+        )
         return {
             "question": question,
             "figures_json": figures_json,
             "solution_parameters_yaml": solution_parameters_yaml,
             "distractor_functions_text": distractor_functions_text,
             "mc_answer_specs_json": dump_mc_answer_specs_json(mc_answer_specs),
+            "choices_yaml": editor_state.choices_yaml,
             "mc_answer_rows": mc_preview["rows"],
             "mc_preview_choices": mc_preview["preview_choices"],
             "mc_preview_answers": mc_preview["preview_answers"],
@@ -433,6 +470,7 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
             "question_id_default": (
                 question.id if question else _suggest_next_question_id()
             ),
+            "editor_state": editor_state.model_dump(mode="json"),
         }
 
     def _parse_chat_history_json(raw: str) -> list[ChatTurn]:
@@ -597,6 +635,50 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
                 ]
             ),
         }
+
+    def _state_from_question(question: Question | None) -> QuestionEditorState:
+        return QuestionEditorState.model_validate(
+            _editor_values_from_question(question)
+        )
+
+    def _build_question_from_editor_state(
+        question_id: str,
+        existing: Question | None,
+        state: QuestionEditorState,
+    ) -> tuple[Question, dict[str, Any], dict[str, Any]]:
+        return _build_question_from_editor_values(
+            question_id, existing, state.model_dump(mode="json")
+        )
+
+    def _editor_response_payload(
+        question: Question,
+        preview: dict[str, Any],
+        mc_preview: dict[str, Any],
+        *,
+        extra: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        editor_state = _state_from_question(question)
+        payload: dict[str, Any] = {
+            "ok": True,
+            "editor_state": editor_state.model_dump(mode="json"),
+            "typed_solution_status": question.solution.typed_solution_status,
+            "calculated_variables_md": preview["calculated_variables_md"],
+            "rendered_answer_md": (
+                question.solution.last_computed_answer_md
+                or preview["rendered_answer_md"]
+            ),
+            "mc_preview_choices": mc_preview["preview_choices"],
+            "mc_preview_answers": mc_preview["preview_answers"],
+            "mc_preview_rationale": mc_preview["preview_rationale"],
+            "mc_preview_warning": mc_preview["warning"],
+            "mc_preview_rows": mc_preview["rows"],
+            "warning": preview["warning"],
+            "answer_formula_warning": preview["warning"],
+        }
+        payload.update(editor_state.model_dump(mode="json"))
+        if extra:
+            payload.update(extra)
+        return payload
 
     def _append_chat_turn(
         question: Question,
@@ -803,45 +885,11 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
                 existing = repo.get_question(question_id)
             except Exception:
                 existing = None
-            question, preview, mc_preview = _build_question_from_editor_values(
-                question_id,
-                existing,
-                {
-                    "title": payload.title,
-                    "points": payload.points,
-                    "question_type": payload.question_type,
-                    "mc_options_guidance": payload.mc_options_guidance,
-                    "question_template_md": payload.question_template_md,
-                    "solution_parameters_yaml": payload.solution_parameters_yaml,
-                    "answer_formula_md": payload.answer_formula_md,
-                    "answer_guidance": payload.answer_guidance,
-                    "distractor_functions_text": payload.distractor_functions_text,
-                    "mc_answer_specs_json": payload.mc_answer_specs_json,
-                    "typed_solution_md": payload.typed_solution_md,
-                    "typed_solution_status": payload.typed_solution_status,
-                    "choices_yaml": payload.choices_yaml,
-                    "figures_json": payload.figures_json,
-                    "chat_history_json": payload.chat_history_json,
-                },
+            question, preview, mc_preview = _build_question_from_editor_state(
+                question_id, existing, payload
             )
             repo.save_question(question)
-            return JSONResponse(
-                {
-                    "ok": True,
-                    "typed_solution_status": question.solution.typed_solution_status,
-                    "calculated_variables_md": preview["calculated_variables_md"],
-                    "rendered_answer_md": (
-                        question.solution.last_computed_answer_md
-                        or preview["rendered_answer_md"]
-                    ),
-                    "mc_preview_choices": mc_preview["preview_choices"],
-                    "mc_preview_answers": mc_preview["preview_answers"],
-                    "mc_preview_rationale": mc_preview["preview_rationale"],
-                    "mc_preview_warning": mc_preview["warning"],
-                    "mc_preview_rows": mc_preview["rows"],
-                    "warning": preview["warning"],
-                }
-            )
+            return JSONResponse(_editor_response_payload(question, preview, mc_preview))
         except Exception as ex:
             return JSONResponse({"ok": False, "error": str(ex)}, status_code=422)
 
@@ -877,26 +925,8 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
                 existing = repo.get_question(question_id)
             except Exception:
                 existing = None
-            live_question, _, _ = _build_question_from_editor_values(
-                question_id,
-                existing,
-                {
-                    "title": payload.editor_state.title,
-                    "points": payload.editor_state.points,
-                    "question_type": payload.editor_state.question_type,
-                    "mc_options_guidance": payload.editor_state.mc_options_guidance,
-                    "question_template_md": payload.editor_state.question_template_md,
-                    "solution_parameters_yaml": payload.editor_state.solution_parameters_yaml,
-                    "answer_formula_md": payload.editor_state.answer_formula_md,
-                    "answer_guidance": payload.editor_state.answer_guidance,
-                    "distractor_functions_text": payload.editor_state.distractor_functions_text,
-                    "mc_answer_specs_json": payload.editor_state.mc_answer_specs_json,
-                    "typed_solution_md": payload.editor_state.typed_solution_md,
-                    "typed_solution_status": payload.editor_state.typed_solution_status,
-                    "choices_yaml": payload.editor_state.choices_yaml,
-                    "figures_json": payload.editor_state.figures_json,
-                    "chat_history_json": payload.editor_state.chat_history_json,
-                },
+            live_question, _, _ = _build_question_from_editor_state(
+                question_id, existing, payload.editor_state
             )
             result = app.state.ai.chat_edit_question(
                 live_question,
@@ -922,22 +952,16 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
                 question.solution.parameters,
             )
             repo.save_question(question)
-            editor_values = _editor_values_from_question(question)
-            return {
-                "ok": True,
-                "assistant_message": result.assistant_message,
-                "warnings": result.warnings,
-                "changed_fields": result.changed_fields + ["chat_history_json"],
-                **editor_values,
-                "calculated_variables_md": preview["calculated_variables_md"],
-                "rendered_answer_md": preview["rendered_answer_md"],
-                "answer_formula_warning": preview["warning"],
-                "mc_preview_choices": mc_preview["preview_choices"],
-                "mc_preview_answers": mc_preview["preview_answers"],
-                "mc_preview_rationale": mc_preview["preview_rationale"],
-                "mc_preview_warning": mc_preview["warning"],
-                "mc_preview_rows": mc_preview["rows"],
-            }
+            return _editor_response_payload(
+                question,
+                preview,
+                mc_preview,
+                extra={
+                    "assistant_message": result.assistant_message,
+                    "warnings": result.warnings,
+                    "changed_fields": result.changed_fields + ["chat_history_json"],
+                },
+            )
         except Exception as ex:
             return JSONResponse({"ok": False, "error": str(ex)}, status_code=422)
 

--- a/src/exam_helper/templates/question_form_v2.html
+++ b/src/exam_helper/templates/question_form_v2.html
@@ -322,6 +322,8 @@
         <textarea hidden name="mc_options_guidance" id="mc_options_guidance">{{ question.mc_options_guidance if question else '' }}</textarea>
         <textarea hidden name="distractor_functions_text" id="distractor_functions_text">{{ distractor_functions_text }}</textarea>
         <textarea hidden name="mc_answer_specs_json" id="mc_answer_specs_json">{{ mc_answer_specs_json }}</textarea>
+        <textarea hidden name="choices_yaml" id="choices_yaml">{{ choices_yaml }}</textarea>
+        <textarea hidden name="typed_solution_md" id="typed_solution_md">{{ question.solution.typed_solution_md if question else '' }}</textarea>
         <textarea hidden name="typed_solution_status" id="typed_solution_status">{{ question.solution.typed_solution_status if question else 'missing' }}</textarea>
         <textarea hidden name="chat_history_json" id="chat_history_json">{{ chat_history_json }}</textarea>
         <div class="row3">
@@ -475,6 +477,8 @@
       const mcOptionsGuidanceEl = document.getElementById("mc_options_guidance");
       const distractorFnsEl = document.getElementById("distractor_functions_text");
       const mcAnswerSpecsEl = document.getElementById("mc_answer_specs_json");
+      const choicesYamlEl = document.getElementById("choices_yaml");
+      const typedSolutionEl = document.getElementById("typed_solution_md");
       const chatHistoryEl = document.getElementById("chat_history_json");
       const renderedAnswerEl = document.getElementById("rendered_answer_md");
       const calculatedVariablesEl = document.getElementById("calculated_variables_md");
@@ -497,6 +501,7 @@
       const chatAttachmentsEl = document.getElementById("chat_attachments");
       const chatPanelEl = document.querySelector(".chat-panel");
       const chatEnabled = {{ 'true' if ai_enabled else 'false' }};
+      let editorState = {{ editor_state | tojson }};
       let autosaveTimer = null;
       let pendingChatFigureIds = [];
 
@@ -520,6 +525,88 @@
 
       function isMC() {
         return questionTypeEl.value === "multiple_choice";
+      }
+
+      function normalizeEditorState(state) {
+        const raw = state || {};
+        return {
+          title: String(raw.title || ""),
+          question_type: String(raw.question_type || "multiple_choice"),
+          mc_options_guidance: String(raw.mc_options_guidance || ""),
+          question_template_md: String(raw.question_template_md || ""),
+          solution_parameters_yaml: String(raw.solution_parameters_yaml || "{}"),
+          answer_formula_md: String(raw.answer_formula_md || ""),
+          answer_guidance: String(raw.answer_guidance || ""),
+          distractor_functions_text: String(raw.distractor_functions_text || ""),
+          mc_answer_specs_json: String(raw.mc_answer_specs_json || "[]"),
+          choices_yaml: String(raw.choices_yaml || "[]"),
+          typed_solution_md: String(raw.typed_solution_md || ""),
+          typed_solution_status: String(raw.typed_solution_status || "missing"),
+          figures_json: String(raw.figures_json || "[]"),
+          chat_history_json: String(raw.chat_history_json || "[]"),
+          points: Number(raw.points || 5),
+        };
+      }
+
+      function collectEditorStateFromDOM() {
+        syncMCSpecsFromDOM();
+        editorState = normalizeEditorState({
+          ...editorState,
+          title: titleEl.value,
+          question_type: questionTypeEl.value,
+          question_template_md: templateEl.value,
+          solution_parameters_yaml: paramsEl.value,
+          answer_formula_md: answerFormulaEl.value,
+          answer_guidance: answerGuidanceEl.value,
+          mc_options_guidance: mcOptionsGuidanceEl.value,
+          distractor_functions_text: distractorFnsEl.value,
+          mc_answer_specs_json: mcAnswerSpecsEl.value,
+          choices_yaml: choicesYamlEl.value || "[]",
+          typed_solution_md: typedSolutionEl.value || "",
+          typed_solution_status: typedStatusEl.value,
+          figures_json: figuresInput.value || "[]",
+          chat_history_json: chatHistoryEl.value || "[]",
+          points: Number(pointsEl.value || 5),
+        });
+        return editorState;
+      }
+
+      function renderEditorState(data = {}) {
+        const nextState = data.editor_state || { ...editorState, ...data };
+        editorState = normalizeEditorState(nextState);
+        titleEl.value = editorState.title;
+        pointsEl.value = editorState.points;
+        questionTypeEl.value = editorState.question_type;
+        templateEl.value = editorState.question_template_md;
+        paramsEl.value = editorState.solution_parameters_yaml;
+        answerFormulaEl.value = editorState.answer_formula_md;
+        answerGuidanceEl.value = editorState.answer_guidance;
+        mcOptionsGuidanceEl.value = editorState.mc_options_guidance;
+        distractorFnsEl.value = editorState.distractor_functions_text;
+        mcAnswerSpecsEl.value = editorState.mc_answer_specs_json;
+        choicesYamlEl.value = editorState.choices_yaml;
+        typedSolutionEl.value = editorState.typed_solution_md;
+        typedStatusEl.value = editorState.typed_solution_status;
+        chatHistoryEl.value = editorState.chat_history_json;
+        figuresInput.value = editorState.figures_json;
+        syncMCRowsFromSpecs(parseMCSpecs());
+        if (typeof data.calculated_variables_md === "string") {
+          calculatedVariablesEl.textContent = data.calculated_variables_md;
+        }
+        answerFormulaWarningEl.textContent = data.warning || data.answer_formula_warning
+          ? `Warning: ${data.warning || data.answer_formula_warning}`
+          : "";
+        renderTemplate();
+        renderMCPreviewFromData(data);
+        renderFiguresPreview();
+        if (typeof data.rendered_answer_md === "string") {
+          renderMarkdownSurface(renderedAnswerEl, data.rendered_answer_md);
+        }
+        updateMCVisibility();
+      }
+
+      function setEditorValuesFromResponse(data) {
+        renderEditorState(data);
       }
 
       function escapeHtml(text) {
@@ -548,6 +635,7 @@
 
       function setFigures(figures) {
         figuresInput.value = JSON.stringify(figures);
+        editorState = normalizeEditorState({ ...editorState, figures_json: figuresInput.value });
         renderFiguresPreview();
       }
 
@@ -725,6 +813,7 @@
       function syncMCSpecsFromDOM() {
         if (!isMC()) {
           mcAnswerSpecsEl.value = "[]";
+          editorState = normalizeEditorState({ ...editorState, mc_answer_specs_json: "[]" });
           return [];
         }
         const specs = Array.from(document.querySelectorAll("[data-mc-row]")).map((row) => {
@@ -736,6 +825,7 @@
           };
         });
         mcAnswerSpecsEl.value = JSON.stringify(specs);
+        editorState = normalizeEditorState({ ...editorState, mc_answer_specs_json: mcAnswerSpecsEl.value });
         return specs;
       }
 
@@ -864,37 +954,8 @@
         chatThreadEl.scrollTop = chatThreadEl.scrollHeight;
       }
 
-      function setEditorValuesFromResponse(data) {
-        if (typeof data.title === "string") titleEl.value = data.title;
-        if (Object.prototype.hasOwnProperty.call(data, "points")) pointsEl.value = data.points;
-        if (typeof data.question_type === "string") questionTypeEl.value = data.question_type;
-        if (typeof data.question_template_md === "string") templateEl.value = data.question_template_md;
-        if (typeof data.solution_parameters_yaml === "string") paramsEl.value = data.solution_parameters_yaml;
-        if (typeof data.answer_formula_md === "string") answerFormulaEl.value = data.answer_formula_md;
-        if (typeof data.answer_guidance === "string") answerGuidanceEl.value = data.answer_guidance;
-        if (typeof data.mc_options_guidance === "string") mcOptionsGuidanceEl.value = data.mc_options_guidance;
-        if (typeof data.distractor_functions_text === "string") distractorFnsEl.value = data.distractor_functions_text;
-        if (typeof data.mc_answer_specs_json === "string") {
-          mcAnswerSpecsEl.value = data.mc_answer_specs_json;
-          syncMCRowsFromSpecs(parseMCSpecs());
-        }
-        if (typeof data.chat_history_json === "string") chatHistoryEl.value = data.chat_history_json;
-        if (typeof data.figures_json === "string") figuresInput.value = data.figures_json;
-        if (typeof data.typed_solution_status === "string") typedStatusEl.value = data.typed_solution_status;
-        if (typeof data.calculated_variables_md === "string") {
-          calculatedVariablesEl.textContent = data.calculated_variables_md;
-        }
-        renderTemplate();
-        renderMCPreviewFromData(data);
-        renderFiguresPreview();
-        if (typeof data.rendered_answer_md === "string") {
-          renderMarkdownSurface(renderedAnswerEl, data.rendered_answer_md);
-        }
-        updateMCVisibility();
-      }
-
       function applyAssistantResponse(data) {
-        setEditorValuesFromResponse(data);
+        renderEditorState(data);
         if (Array.isArray(data.warnings) && data.warnings.length) {
           setChatStatus(data.warnings.join(" | "), "warn");
         } else {
@@ -949,22 +1010,7 @@
       }
 
       function serializePayload() {
-        syncMCSpecsFromDOM();
-        return {
-          title: titleEl.value,
-          question_type: questionTypeEl.value,
-          question_template_md: templateEl.value,
-          solution_parameters_yaml: paramsEl.value,
-          answer_formula_md: answerFormulaEl.value,
-          answer_guidance: answerGuidanceEl.value,
-          mc_options_guidance: mcOptionsGuidanceEl.value,
-          distractor_functions_text: distractorFnsEl.value,
-          mc_answer_specs_json: mcAnswerSpecsEl.value,
-          typed_solution_status: typedStatusEl.value,
-          figures_json: figuresInput.value || "[]",
-          chat_history_json: chatHistoryEl.value || "[]",
-          points: Number(pointsEl.value || 5),
-        };
+        return { ...collectEditorStateFromDOM() };
       }
 
       async function autosaveNow() {
@@ -981,14 +1027,7 @@
           setStatus(`Save error: ${data.error || res.statusText}`, "warn");
           throw new Error(data.error || res.statusText);
         }
-        if (typeof data.calculated_variables_md === "string") {
-          calculatedVariablesEl.textContent = data.calculated_variables_md;
-        }
-        if (typeof data.rendered_answer_md === "string") {
-          renderMarkdownSurface(renderedAnswerEl, data.rendered_answer_md);
-        }
-        renderMCPreviewFromData(data);
-        answerFormulaWarningEl.textContent = data.warning ? `Warning: ${data.warning}` : "";
+        renderEditorState(data);
         const statusWarning = [data.warning, data.mc_preview_warning].filter(Boolean).join(" | ");
         setStatus(statusWarning ? "Saved with warning" : "Saved", statusWarning ? "warn" : "good");
       }
@@ -1111,6 +1150,7 @@
       });
 
       form.addEventListener("submit", () => {
+        collectEditorStateFromDOM();
         setStatus("Saving...", "warn");
       });
 
@@ -1124,7 +1164,7 @@
         }
       });
 
-      renderTemplate();
+      renderEditorState({ editor_state: editorState });
       syncMCSpecsFromDOM();
       renderMCPreviewFromData({
         mc_preview_choices: {{ mc_preview_choices | tojson }},

--- a/src/exam_helper/templates/question_form_v2.html
+++ b/src/exam_helper/templates/question_form_v2.html
@@ -544,7 +544,7 @@
           typed_solution_status: String(raw.typed_solution_status || "missing"),
           figures_json: String(raw.figures_json || "[]"),
           chat_history_json: String(raw.chat_history_json || "[]"),
-          points: Number(raw.points || 5),
+          points: Number(raw.points ?? 5),
         };
       }
 

--- a/tests/integration/test_autosave_and_ai_errors.py
+++ b/tests/integration/test_autosave_and_ai_errors.py
@@ -786,27 +786,44 @@ def test_autosave_after_chat_keeps_chat_applied_solution_fields(tmp_path) -> Non
     assert chat_resp.status_code == 200
     body = chat_resp.json()
 
+    assert body["editor_state"]["answer_formula_md"] == "answer = 9"
+    assert json.loads(body["editor_state"]["mc_answer_specs_json"])[0] == {
+        "formula_md": "answer = 1",
+        "rationale_md": "r1",
+    }
+
     autosave_resp = client.post(
         "/questions/q_chat_autosave/autosave",
-        json={
-            "title": body["title"],
-            "question_type": body["question_type"],
-            "mc_options_guidance": body["mc_options_guidance"],
-            "question_template_md": body["question_template_md"],
-            "solution_parameters_yaml": body["solution_parameters_yaml"],
-            "answer_formula_md": body["answer_formula_md"],
-            "answer_guidance": body["answer_guidance"],
-            "distractor_functions_text": body["distractor_functions_text"],
-            "mc_answer_specs_json": body["mc_answer_specs_json"],
-            "choices_yaml": body["choices_yaml"],
-            "typed_solution_md": body["typed_solution_md"],
-            "typed_solution_status": body["typed_solution_status"],
-            "figures_json": body["figures_json"],
-            "chat_history_json": body["chat_history_json"],
-            "points": body["points"],
-        },
+        json=body["editor_state"],
     )
     assert autosave_resp.status_code == 200
+    autosave_body = autosave_resp.json()
+    assert (
+        autosave_body["editor_state"]["answer_formula_md"]
+        == body["editor_state"]["answer_formula_md"]
+    )
+    assert (
+        autosave_body["editor_state"]["mc_answer_specs_json"]
+        == body["editor_state"]["mc_answer_specs_json"]
+    )
+    assert (
+        autosave_body["editor_state"]["chat_history_json"]
+        == body["editor_state"]["chat_history_json"]
+    )
+
     saved = repo.get_question("q_chat_autosave")
     assert saved.solution.answer_formula_md == "answer = 9"
     assert len(saved.solution.mc_answer_specs) == 4
+    saved_state = _editor_state_for_question(saved)
+    assert (
+        saved_state["answer_formula_md"]
+        == autosave_body["editor_state"]["answer_formula_md"]
+    )
+    assert (
+        saved_state["mc_answer_specs_json"]
+        == autosave_body["editor_state"]["mc_answer_specs_json"]
+    )
+    assert (
+        saved_state["chat_history_json"]
+        == autosave_body["editor_state"]["chat_history_json"]
+    )


### PR DESCRIPTION
## Summary
- Introduce a typed `QuestionEditorState` contract shared by autosave and chat.
- Return canonical `editor_state` payloads from autosave/chat while preserving flat response fields for compatibility.
- Make the question editor maintain and re-render from a single in-memory editor state object.
- Add chat-to-autosave round-trip coverage for the returned editor state.

Fixes #77

## Validation
- `uv run --extra dev pytest -q`
- `uv run --extra dev black --check .`

## Risk
- Moderate UI risk due to editor JavaScript restructuring; covered by existing browser round-trip tests.