### PR TITLE
Add configurable chat history window

### DIFF
--- a/src/exam_helper/ai_service.py
+++ b/src/exam_helper/ai_service.py
@@ -297,7 +297,7 @@ class AIService:
     @staticmethod
     def _truncate_chat_history(turns: list[ChatTurn], keep: int = 5) -> list[ChatTurn]:
         if keep <= 0:
-            return []
+            return [turn.model_copy(deep=True) for turn in turns]
         return [turn.model_copy(deep=True) for turn in turns[-keep:]]
 
     @staticmethod

--- a/src/exam_helper/ai_service.py
+++ b/src/exam_helper/ai_service.py
@@ -636,12 +636,15 @@ class AIService:
         question: Question,
         user_message: str,
         attached_figure_ids: list[str] | None = None,
+        history_keep_count: int = 5,
     ) -> QuestionEditorResult:
         client = self._client()
         working = question.model_copy(deep=True)
         changed_fields: set[str] = set()
         warnings: list[str] = []
-        recent_history = self._truncate_chat_history(working.solution.chat_history)
+        recent_history = self._truncate_chat_history(
+            working.solution.chat_history, keep=history_keep_count
+        )
         state = self._editor_state_for_question(working)
         state_json = json.dumps(
             state.model_dump(mode="json"), ensure_ascii=False, indent=2

--- a/src/exam_helper/app.py
+++ b/src/exam_helper/app.py
@@ -64,7 +64,7 @@ class ChatPayload(BaseModel):
     message: str = ""
     attached_figure_ids: list[str] = Field(default_factory=list)
     editor_state: QuestionEditorState
-    history_keep_count: int = Field(default=5, ge=1)
+    history_keep_count: int = Field(default=5, ge=0)
 
 
 def _sanitize_docx_filename_stem(project_name: str) -> str:

--- a/src/exam_helper/app.py
+++ b/src/exam_helper/app.py
@@ -12,7 +12,7 @@ import yaml
 from fastapi import Body, FastAPI, Form, Request
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
 from fastapi.templating import Jinja2Templates
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from exam_helper.ai_service import AIService
 from exam_helper.export_docx import render_project_docx_bytes
@@ -62,8 +62,9 @@ AutosavePayload = QuestionEditorState
 
 class ChatPayload(BaseModel):
     message: str = ""
-    attached_figure_ids: list[str] = []
+    attached_figure_ids: list[str] = Field(default_factory=list)
     editor_state: QuestionEditorState
+    history_keep_count: int = Field(default=5, ge=1)
 
 
 def _sanitize_docx_filename_stem(project_name: str) -> str:
@@ -406,7 +407,7 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
         chat_history_json = json.dumps(
             [
                 turn.model_dump(mode="json")
-                for turn in (question.solution.chat_history[-5:] if question else [])
+                for turn in (question.solution.chat_history if question else [])
             ]
         )
         editor_state = QuestionEditorState(
@@ -466,6 +467,7 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
                 else answer_preview["rendered_answer_md"]
             ),
             "chat_history_json": chat_history_json,
+            "chat_history_keep_count_default": 5,
             "ai_enabled": bool(openai_key),
             "question_id_default": (
                 question.id if question else _suggest_next_question_id()
@@ -477,7 +479,7 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
         loaded = json.loads(raw or "[]")
         if not isinstance(loaded, list):
             raise ValueError("chat_history_json must be a JSON list.")
-        return [ChatTurn.model_validate(item) for item in loaded][-5:]
+        return [ChatTurn.model_validate(item) for item in loaded]
 
     def _build_question_from_editor_values(
         question_id: str,
@@ -629,9 +631,7 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
             "chat_history_json": json.dumps(
                 [
                     turn.model_dump(mode="json")
-                    for turn in (
-                        question.solution.chat_history[-5:] if question else []
-                    )
+                    for turn in (question.solution.chat_history if question else [])
                 ]
             ),
         }
@@ -687,16 +687,13 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
         assistant_message: str,
         attached_figure_ids: list[str],
     ) -> None:
-        question.solution.chat_history = (
-            question.solution.chat_history
-            + [
-                ChatTurn(
-                    user_message=user_message.strip(),
-                    assistant_message=assistant_message.strip(),
-                    attached_figure_ids=attached_figure_ids[:],
-                )
-            ]
-        )[-5:]
+        question.solution.chat_history = question.solution.chat_history + [
+            ChatTurn(
+                user_message=user_message.strip(),
+                assistant_message=assistant_message.strip(),
+                attached_figure_ids=attached_figure_ids[:],
+            )
+        ]
 
     def _compute_answer_preview(question: Question | None) -> dict[str, str]:
         """Build the non-editable answer preview payload for the editor UI."""
@@ -932,6 +929,7 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
                 live_question,
                 payload.message,
                 attached_figure_ids=payload.attached_figure_ids,
+                history_keep_count=payload.history_keep_count,
             )
             repo.add_ai_usage(result.usage)
             question = result.question

--- a/src/exam_helper/templates/question_form_v2.html
+++ b/src/exam_helper/templates/question_form_v2.html
@@ -388,11 +388,12 @@
               <input
                 id="chat_history_keep_count"
                 type="number"
-                min="1"
+                min="0"
                 step="1"
                 value="{{ chat_history_keep_count_default }}"
                 {% if not ai_enabled %}disabled{% endif %}
                 aria-label="Messages sent back to the LLM"
+                title="Set to 0 to send the full chat history back to the LLM."
               />
               <span>turns back to the LLM</span>
             </div>
@@ -569,7 +570,7 @@
 
       function chatHistoryKeepCount() {
         const raw = Number.parseInt(chatHistoryKeepCountEl.value || "5", 10);
-        if (!Number.isFinite(raw) || raw < 1) {
+        if (!Number.isFinite(raw) || raw < 0) {
           return 5;
         }
         return raw;

--- a/src/exam_helper/templates/question_form_v2.html
+++ b/src/exam_helper/templates/question_form_v2.html
@@ -250,6 +250,35 @@
         background: #fff;
         padding: 0.85rem;
       }
+      .chat-history-window {
+        display: flex;
+        align-items: center;
+        gap: 0.55rem;
+        color: var(--muted);
+        font-size: 0.94rem;
+      }
+      .chat-history-window input {
+        width: 5.5rem;
+        margin: 0;
+      }
+      .chat-history-separator {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        margin: 0.3rem 0;
+        color: var(--muted);
+        font-size: 0.8rem;
+        letter-spacing: 0.02em;
+      }
+      .chat-history-separator::before,
+      .chat-history-separator::after {
+        content: "";
+        flex: 1;
+        border-top: 1px solid var(--line);
+      }
+      .chat-history-separator span {
+        white-space: nowrap;
+      }
       .chat-message {
         border-radius: 14px;
         padding: 0.75rem 0.85rem;
@@ -354,6 +383,19 @@
           <div class="chat-panel-body">
             <p class="hint">{{ 'Ask for a rewrite, a cleanup pass, a distractor tweak, or a question-specific edit. Enter adds a newline. Use Shift+Enter to send.' if ai_enabled else 'Chat is disabled until an OpenAI key is configured.' }}</p>
             <div id="chat_thread" class="chat-log" aria-live="polite"></div>
+            <div class="chat-history-window">
+              <span>Sending the last</span>
+              <input
+                id="chat_history_keep_count"
+                type="number"
+                min="1"
+                step="1"
+                value="{{ chat_history_keep_count_default }}"
+                {% if not ai_enabled %}disabled{% endif %}
+                aria-label="Messages sent back to the LLM"
+              />
+              <span>turns back to the LLM</span>
+            </div>
             <div class="chat-input-row">
               <textarea
                 id="chat_message"
@@ -495,6 +537,7 @@
       const mcPreviewRationale = document.getElementById("mc_preview_rationale");
       const mcPreviewWarning = document.getElementById("mc_preview_warning");
       const chatThreadEl = document.getElementById("chat_thread");
+      const chatHistoryKeepCountEl = document.getElementById("chat_history_keep_count");
       const chatMessageEl = document.getElementById("chat_message");
       const chatSendBtn = document.getElementById("btn_send_chat");
       const chatStatusEl = document.getElementById("chat_status");
@@ -517,10 +560,19 @@
 
       function setChatBusy(isBusy) {
         const disabled = !chatEnabled || isBusy;
+        chatHistoryKeepCountEl.disabled = disabled;
         chatSendBtn.disabled = disabled;
         chatMessageEl.disabled = disabled;
         chatPanelEl.classList.toggle("is-busy", isBusy);
         chatPanelEl.setAttribute("aria-busy", isBusy ? "true" : "false");
+      }
+
+      function chatHistoryKeepCount() {
+        const raw = Number.parseInt(chatHistoryKeepCountEl.value || "5", 10);
+        if (!Number.isFinite(raw) || raw < 1) {
+          return 5;
+        }
+        return raw;
       }
 
       function isMC() {
@@ -599,6 +651,7 @@
         renderTemplate();
         renderMCPreviewFromData(data);
         renderFiguresPreview();
+        renderChatHistory();
         if (typeof data.rendered_answer_md === "string") {
           renderMarkdownSurface(renderedAnswerEl, data.rendered_answer_md);
         }
@@ -939,7 +992,7 @@
         )).join("");
       }
 
-      function renderChatMessage(role, text, attachedFigureIds = []) {
+      function createChatMessageElement(role, text, attachedFigureIds = []) {
         const item = document.createElement("div");
         item.className = `chat-message ${role}`;
         const attachments = Array.isArray(attachedFigureIds) && attachedFigureIds.length
@@ -950,7 +1003,45 @@
           <div>${escapeHtml(String(text || "")).replace(/\n/g, "<br>")}</div>
           ${attachments}
         `;
+        return item;
+      }
+
+      function renderChatMessage(role, text, attachedFigureIds = []) {
+        const item = createChatMessageElement(role, text, attachedFigureIds);
         chatThreadEl.appendChild(item);
+        chatThreadEl.scrollTop = chatThreadEl.scrollHeight;
+      }
+
+      function renderChatHistorySeparator() {
+        const item = document.createElement("div");
+        item.className = "chat-history-separator";
+        item.innerHTML = "<span>Messages above this line are not sent to the LLM.</span>";
+        return item;
+      }
+
+      function renderChatHistory() {
+        const history = parseChatHistory();
+        chatThreadEl.innerHTML = "";
+        if (!history.length) {
+          return;
+        }
+        const keepCount = chatHistoryKeepCount();
+        const splitIndex = Math.max(0, history.length - keepCount);
+        history.forEach((turn, idx) => {
+          if (idx === splitIndex && splitIndex > 0) {
+            chatThreadEl.appendChild(renderChatHistorySeparator());
+          }
+          chatThreadEl.appendChild(
+            createChatMessageElement(
+              "user",
+              turn.user_message || "",
+              turn.attached_figure_ids || []
+            )
+          );
+          chatThreadEl.appendChild(
+            createChatMessageElement("assistant", turn.assistant_message || "")
+          );
+        });
         chatThreadEl.scrollTop = chatThreadEl.scrollHeight;
       }
 
@@ -985,6 +1076,7 @@
             body: JSON.stringify({
               message,
               attached_figure_ids: attachedFigureIds,
+              history_keep_count: chatHistoryKeepCount(),
               editor_state: serializePayload(),
             }),
           });
@@ -1157,6 +1249,9 @@
       chatSendBtn.addEventListener("click", () => {
         sendChatMessage().catch((err) => setChatStatus(`Chat error: ${err.message}`, "warn"));
       });
+      chatHistoryKeepCountEl.addEventListener("input", () => {
+        renderChatHistory();
+      });
       chatMessageEl.addEventListener("keydown", (event) => {
         if (event.key === "Enter" && event.shiftKey) {
           event.preventDefault();
@@ -1180,13 +1275,7 @@
       renderMarkdownSurface(renderedAnswerEl, renderedAnswerEl.textContent || "");
       updateMCVisibility();
       renderFiguresPreview();
-      const existingChatHistory = parseChatHistory();
-      if (existingChatHistory.length) {
-        for (const turn of existingChatHistory) {
-          renderChatMessage("user", turn.user_message || "", turn.attached_figure_ids || []);
-          renderChatMessage("assistant", turn.assistant_message || "");
-        }
-      }
+      renderChatHistory();
       setChatBusy(false);
       renderPendingChatAttachments();
     </script>

--- a/src/exam_helper/templates/question_form_v2.html
+++ b/src/exam_helper/templates/question_form_v2.html
@@ -569,11 +569,15 @@
       }
 
       function chatHistoryKeepCount() {
-        const raw = Number.parseInt(chatHistoryKeepCountEl.value || "5", 10);
-        if (!Number.isFinite(raw) || raw < 0) {
-          return 5;
+        const raw = Number.parseInt(chatHistoryKeepCountEl.value, 10);
+        if (Number.isFinite(raw) && raw >= 0) {
+          return raw;
         }
-        return raw;
+        const fallback = Number.parseInt(chatHistoryKeepCountEl.defaultValue, 10);
+        if (Number.isFinite(fallback) && fallback >= 0) {
+          return fallback;
+        }
+        return 0;
       }
 
       function isMC() {

--- a/tests/integration/test_app_ai_config_and_usage.py
+++ b/tests/integration/test_app_ai_config_and_usage.py
@@ -4,7 +4,7 @@ from fastapi.testclient import TestClient
 
 from exam_helper.ai_service import AIService
 from exam_helper.app import create_app
-from exam_helper.models import AIUsageTotals
+from exam_helper.models import AIUsageTotals, ChatTurn
 from exam_helper.repository import ProjectRepository
 
 
@@ -44,6 +44,7 @@ def test_question_editor_has_chat_workflow_hooks(tmp_path) -> None:
     assert '<details class="card chat-panel"' in resp.text
     assert "<summary>Chat Assistant</summary>" in resp.text
     assert 'id="chat_thread"' in resp.text
+    assert 'id="chat_history_keep_count"' in resp.text
     assert 'id="chat_message"' in resp.text
     assert 'id="btn_send_chat"' in resp.text
     assert "formula-preview--compact" in resp.text
@@ -54,6 +55,43 @@ def test_question_editor_has_chat_workflow_hooks(tmp_path) -> None:
     assert 'title="No API key configured."' in resp.text
     assert "setChatBusy(true)" in resp.text
     assert 'event.key === "Enter" && event.shiftKey' in resp.text
+
+
+def test_question_editor_embeds_full_chat_history_and_window_control(tmp_path) -> None:
+    repo = ProjectRepository(tmp_path)
+    repo.init_project("Exam", "Physics")
+    app = create_app(tmp_path, openai_key=None)
+    client = TestClient(app)
+    client.post(
+        "/questions/save",
+        data={
+            "question_id": "q_history",
+            "title": "T",
+            "question_type": "free_response",
+            "prompt_md": "P",
+            "question_template_md": "P",
+            "choices_yaml": "[]",
+            "typed_solution_md": "",
+            "distractor_functions_text": "",
+            "figures_json": "[]",
+            "points": 5,
+        },
+    )
+    seeded = repo.get_question("q_history")
+    seeded.solution.chat_history = [
+        ChatTurn(user_message=f"user {idx}", assistant_message=f"assistant {idx}")
+        for idx in range(1, 7)
+    ]
+    repo.save_question(seeded)
+
+    resp = client.get("/questions/q_history/edit")
+    assert resp.status_code == 200
+    assert 'id="chat_history_keep_count"' in resp.text
+    assert 'value="5"' in resp.text
+    assert "Sending the last" in resp.text
+    assert "Messages above this line are not sent to the LLM." in resp.text
+    assert "user 1" in resp.text
+    assert "user 6" in resp.text
 
 
 def test_question_editor_rendering_is_stable(tmp_path) -> None:

--- a/tests/integration/test_app_ai_config_and_usage.py
+++ b/tests/integration/test_app_ai_config_and_usage.py
@@ -45,6 +45,9 @@ def test_question_editor_has_chat_workflow_hooks(tmp_path) -> None:
     assert "<summary>Chat Assistant</summary>" in resp.text
     assert 'id="chat_thread"' in resp.text
     assert 'id="chat_history_keep_count"' in resp.text
+    assert (
+        'title="Set to 0 to send the full chat history back to the LLM."' in resp.text
+    )
     assert 'id="chat_message"' in resp.text
     assert 'id="btn_send_chat"' in resp.text
     assert "formula-preview--compact" in resp.text

--- a/tests/integration/test_autosave_and_ai_errors.py
+++ b/tests/integration/test_autosave_and_ai_errors.py
@@ -597,7 +597,13 @@ def test_ai_chat_updates_question_and_returns_payload(tmp_path) -> None:
     _seed_question(client, "q_chat")
 
     class _AI:
-        def chat_edit_question(self, question, user_message, attached_figure_ids=None):
+        def chat_edit_question(
+            self,
+            question,
+            user_message,
+            attached_figure_ids=None,
+            history_keep_count=None,
+        ):
             assert question.id == "q_chat"
             assert user_message == "Please clean this up."
             assert attached_figure_ids == []
@@ -651,7 +657,13 @@ def test_ai_chat_refreshes_rendered_answer_when_guidance_changes(tmp_path) -> No
     repo.save_question(seeded)
 
     class _AI:
-        def chat_edit_question(self, question, user_message, attached_figure_ids=None):
+        def chat_edit_question(
+            self,
+            question,
+            user_message,
+            attached_figure_ids=None,
+            history_keep_count=None,
+        ):
             updated = question.model_copy(deep=True)
             updated.solution.answer_guidance = "New answer: {{answer}}"
             updated.solution.last_computed_answer_md = "Stale answer: 9"
@@ -680,7 +692,7 @@ def test_ai_chat_refreshes_rendered_answer_when_guidance_changes(tmp_path) -> No
     assert saved.solution.last_computed_answer_md == "New answer: 9"
 
 
-def test_ai_chat_uses_live_editor_state_and_persists_last_five_turns(tmp_path) -> None:
+def test_ai_chat_uses_live_editor_state_and_persists_full_history(tmp_path) -> None:
     repo = ProjectRepository(tmp_path)
     repo.init_project("Exam", "Physics")
     app = create_app(tmp_path, openai_key="k")
@@ -694,10 +706,17 @@ def test_ai_chat_uses_live_editor_state_and_persists_last_five_turns(tmp_path) -
     repo.save_question(seeded)
 
     class _AI:
-        def chat_edit_question(self, question, user_message, attached_figure_ids=None):
+        def chat_edit_question(
+            self,
+            question,
+            user_message,
+            attached_figure_ids=None,
+            history_keep_count=None,
+        ):
             assert question.title == "Unsaved local title"
             assert question.solution.question_template_md == "Unsaved local template"
             assert attached_figure_ids == ["fig_1"]
+            assert history_keep_count == 5
             updated = question.model_copy(deep=True)
             updated.solution.answer_formula_md = "answer = 12"
             updated.solution.answer_guidance = "{{answer}}"
@@ -743,10 +762,50 @@ def test_ai_chat_uses_live_editor_state_and_persists_last_five_turns(tmp_path) -
     assert saved.title == "Unsaved local title"
     assert saved.solution.question_template_md == "Unsaved local template"
     assert saved.solution.last_computed_answer_md == "12"
-    assert len(saved.solution.chat_history) == 5
+    assert len(saved.solution.chat_history) == 6
     assert saved.solution.chat_history[-1].user_message == "Compute the answer."
     assert saved.solution.chat_history[-1].attached_figure_ids == ["fig_1"]
-    assert saved.solution.chat_history[0].user_message == "user 2"
+    assert saved.solution.chat_history[0].user_message == "user 1"
+
+
+def test_ai_chat_forwards_requested_history_window(tmp_path) -> None:
+    repo = ProjectRepository(tmp_path)
+    repo.init_project("Exam", "Physics")
+    app = create_app(tmp_path, openai_key="k")
+    client = TestClient(app)
+    _seed_question(client, "q_history_window")
+
+    class _AI:
+        def chat_edit_question(
+            self,
+            question,
+            user_message,
+            attached_figure_ids=None,
+            history_keep_count=None,
+        ):
+            assert history_keep_count == 2
+            updated = question.model_copy(deep=True)
+            updated.solution.last_computed_answer_md = "ok"
+            return AIService.QuestionEditorResult(
+                assistant_message="Stored the answer.",
+                question=updated,
+                warnings=[],
+                usage=AIUsageTotals(),
+                changed_fields=[],
+            )
+
+    app.state.ai = _AI()
+    original = repo.get_question("q_history_window")
+    resp = client.post(
+        "/questions/q_history_window/ai/chat",
+        json={
+            "message": "Please keep only two turns.",
+            "attached_figure_ids": [],
+            "history_keep_count": 2,
+            "editor_state": _editor_state_for_question(original),
+        },
+    )
+    assert resp.status_code == 200
 
 
 def test_autosave_after_chat_keeps_chat_applied_solution_fields(tmp_path) -> None:
@@ -757,7 +816,13 @@ def test_autosave_after_chat_keeps_chat_applied_solution_fields(tmp_path) -> Non
     _seed_question(client, "q_chat_autosave", qtype="multiple_choice")
 
     class _AI:
-        def chat_edit_question(self, question, user_message, attached_figure_ids=None):
+        def chat_edit_question(
+            self,
+            question,
+            user_message,
+            attached_figure_ids=None,
+            history_keep_count=None,
+        ):
             updated = question.model_copy(deep=True)
             updated.solution.answer_formula_md = "answer = 9"
             updated.solution.answer_guidance = "{{answer}}"

--- a/tests/unit/test_ai_service.py
+++ b/tests/unit/test_ai_service.py
@@ -331,3 +331,49 @@ def test_ai_service_chat_edit_question_truncates_history_by_requested_count(
     assert "assistant 6" in history_block
     assert "user 1" not in history_block
     assert "assistant 3" not in history_block
+
+
+def test_ai_service_chat_edit_question_uses_full_history_when_keep_is_zero(
+    monkeypatch,
+) -> None:
+    from exam_helper import ai_service as mod
+    from exam_helper.models import ChatTurn
+
+    class _RecordingResponses:
+        def __init__(self):
+            self.calls = []
+
+        def create(self, **kwargs):
+            self.calls.append(kwargs)
+
+            class R:
+                pass
+
+            r = R()
+            r.output_text = '{"assistant_message":"Updated.","warnings":[]}'
+            r.output = []
+            r.id = "resp_1"
+            return r
+
+    class _RecordingClient:
+        def __init__(self):
+            self.responses = _RecordingResponses()
+
+    recording_client = _RecordingClient()
+    monkeypatch.setattr(mod, "OpenAI", lambda api_key: recording_client)
+    svc = AIService(api_key="k")
+    q = Question(id="q1", title="Original")
+    q.solution.chat_history = [
+        ChatTurn(user_message=f"user {idx}", assistant_message=f"assistant {idx}")
+        for idx in range(1, 4)
+    ]
+
+    out = svc.chat_edit_question(q, "rewrite this", history_keep_count=0)
+
+    assert out.assistant_message == "Updated."
+    prompt_text = recording_client.responses.calls[0]["input"][1]["content"][0]["text"]
+    history_block = prompt_text.split("Persisted recent chat history:\n", 1)[1].split(
+        "\n\nCurrent author request:\n", 1
+    )[0]
+    assert "user 1" in history_block
+    assert "assistant 3" in history_block

--- a/tests/unit/test_ai_service.py
+++ b/tests/unit/test_ai_service.py
@@ -282,3 +282,52 @@ def test_ai_service_chat_edit_question_uses_tool_calls(monkeypatch) -> None:
         "question_template_md",
     ]
     assert out.warnings == ["Validated the deterministic answer formula."]
+
+
+def test_ai_service_chat_edit_question_truncates_history_by_requested_count(
+    monkeypatch,
+) -> None:
+    from exam_helper import ai_service as mod
+    from exam_helper.models import ChatTurn
+
+    class _RecordingResponses:
+        def __init__(self):
+            self.calls = []
+
+        def create(self, **kwargs):
+            self.calls.append(kwargs)
+
+            class R:
+                pass
+
+            r = R()
+            r.output_text = '{"assistant_message":"Updated.","warnings":[]}'
+            r.output = []
+            r.id = "resp_1"
+            return r
+
+    class _RecordingClient:
+        def __init__(self):
+            self.responses = _RecordingResponses()
+
+    recording_client = _RecordingClient()
+    monkeypatch.setattr(mod, "OpenAI", lambda api_key: recording_client)
+    svc = AIService(api_key="k")
+    q = Question(id="q1", title="Original")
+    q.solution.chat_history = [
+        ChatTurn(user_message=f"user {idx}", assistant_message=f"assistant {idx}")
+        for idx in range(1, 7)
+    ]
+
+    out = svc.chat_edit_question(q, "rewrite this", history_keep_count=3)
+
+    assert out.assistant_message == "Updated."
+    assert len(recording_client.responses.calls) == 1
+    prompt_text = recording_client.responses.calls[0]["input"][1]["content"][0]["text"]
+    history_block = prompt_text.split("Persisted recent chat history:\n", 1)[1].split(
+        "\n\nCurrent author request:\n", 1
+    )[0]
+    assert "user 4" in history_block
+    assert "assistant 6" in history_block
+    assert "user 1" not in history_block
+    assert "assistant 3" not in history_block


### PR DESCRIPTION
Fixes #75

- Add a per-chat history window control in the question editor.
- Preserve the full chat transcript in saved state and show a separator before messages that are no longer sent to the LLM.
- Forward the selected history window to the AI chat request and truncate only the prompt-side history.

Validation:
- `uv run --extra dev pytest -q tests/unit/test_ai_service.py tests/integration/test_app_ai_config_and_usage.py tests/integration/test_autosave_and_ai_errors.py`
- `uv run --extra dev black --check .`
- `uv run --extra dev pytest -q`

Remaining risk:
- The history window is intentionally transient and resets on each editor load, which matches the issue but means users must reselect it per page session.