### PR TITLE
Switch default exam model to gpt-5.4

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,7 +8,7 @@
 ## 2. Create an exam project
 
 ```bash
-uv run exam-helper init my-exam --name "Exam Draft" --course "Physics 1" --openai-model gpt-5.2
+uv run exam-helper init my-exam --name "Exam Draft" --course "Physics 1" --openai-model gpt-5.4
 ```
 
 This creates:

--- a/src/exam_helper/ai_service.py
+++ b/src/exam_helper/ai_service.py
@@ -14,6 +14,7 @@ from exam_helper.models import (
     AIPromptConfig,
     AIUsageTotals,
     ChatTurn,
+    DEFAULT_OPENAI_MODEL,
     DistractorFunction,
     MCAnswerSpec,
     Question,
@@ -35,7 +36,7 @@ logger = logging.getLogger(__name__)
 @dataclass
 class AIService:
     api_key: str | None
-    model: str = "gpt-5.2"
+    model: str = DEFAULT_OPENAI_MODEL
     prompts_override: AIPromptConfig | None = None
     prompt_catalog: PromptCatalog | None = None
 

--- a/src/exam_helper/app.py
+++ b/src/exam_helper/app.py
@@ -19,6 +19,7 @@ from exam_helper.export_docx import render_project_docx_bytes
 from exam_helper.models import (
     AIUsageTotals,
     ChatTurn,
+    DEFAULT_OPENAI_MODEL,
     DistractorFunction,
     MCAnswerSpec,
     MCChoice,
@@ -787,7 +788,7 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
                 "project": project,
                 "questions": questions,
                 "export_warning": export_warning,
-                "ai_model": (project.ai.model if project else "gpt-5.2"),
+                "ai_model": (project.ai.model if project else DEFAULT_OPENAI_MODEL),
                 "ai_usage": (project.ai.usage if project else AIUsageTotals()),
                 "ai_prompts": (project.ai.prompts if project else None),
             },
@@ -1229,13 +1230,13 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
 
     @app.post("/project/settings")
     def save_project_settings(
-        openai_model: str = Form("gpt-5.2"),
+        openai_model: str = Form(DEFAULT_OPENAI_MODEL),
         prompt_overall: str = Form(""),
         prompt_solution_and_mc: str = Form(""),
         prompt_prompt_review: str = Form(""),
     ) -> RedirectResponse:
         project = repo.load_project()
-        project.ai.model = openai_model.strip() or "gpt-5.2"
+        project.ai.model = openai_model.strip() or DEFAULT_OPENAI_MODEL
         project.ai.prompts.overall = prompt_overall
         project.ai.prompts.solution_and_mc = prompt_solution_and_mc
         project.ai.prompts.prompt_review = prompt_prompt_review
@@ -1245,14 +1246,14 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
 
     @app.post("/project/settings/autosave")
     def autosave_project_settings(
-        openai_model: str = Form("gpt-5.2"),
+        openai_model: str = Form(DEFAULT_OPENAI_MODEL),
         prompt_overall: str = Form(""),
         prompt_solution_and_mc: str = Form(""),
         prompt_prompt_review: str = Form(""),
     ) -> JSONResponse:
         try:
             project = repo.load_project()
-            project.ai.model = openai_model.strip() or "gpt-5.2"
+            project.ai.model = openai_model.strip() or DEFAULT_OPENAI_MODEL
             project.ai.prompts.overall = prompt_overall
             project.ai.prompts.solution_and_mc = prompt_solution_and_mc
             project.ai.prompts.prompt_review = prompt_prompt_review

--- a/src/exam_helper/cli.py
+++ b/src/exam_helper/cli.py
@@ -9,6 +9,7 @@ import uvicorn
 from exam_helper.app import create_app
 from exam_helper.config import resolve_openai_api_key
 from exam_helper.export_docx import export_project_to_docx
+from exam_helper.models import DEFAULT_OPENAI_MODEL
 from exam_helper.repository import ProjectRepository
 from exam_helper.validation import validate_project
 
@@ -82,7 +83,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_init.add_argument("path")
     p_init.add_argument("--name", default="Example Exam Project")
     p_init.add_argument("--course", default="Calculus-based Intro Physics")
-    p_init.add_argument("--openai-model", default="gpt-5.2")
+    p_init.add_argument("--openai-model", default=DEFAULT_OPENAI_MODEL)
     p_init.set_defaults(func=cmd_init)
 
     p_serve = sub.add_parser("serve", help="Serve the local web app.")

--- a/src/exam_helper/models.py
+++ b/src/exam_helper/models.py
@@ -6,6 +6,8 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+DEFAULT_OPENAI_MODEL = "gpt-5.4"
+
 
 class QuestionType(str, Enum):
     free_response = "free_response"
@@ -129,7 +131,7 @@ class AIUsageTotals(BaseModel):
 
 
 class AIConfig(BaseModel):
-    model: str = "gpt-5.2"
+    model: str = DEFAULT_OPENAI_MODEL
     prompts: AIPromptConfig = Field(default_factory=AIPromptConfig)
     usage: AIUsageTotals = Field(default_factory=AIUsageTotals)
 

--- a/src/exam_helper/repository.py
+++ b/src/exam_helper/repository.py
@@ -5,7 +5,12 @@ from pathlib import Path
 
 import yaml
 
-from exam_helper.models import AIUsageTotals, ProjectConfig, Question
+from exam_helper.models import (
+    AIUsageTotals,
+    DEFAULT_OPENAI_MODEL,
+    ProjectConfig,
+    Question,
+)
 
 
 def _natural_sort_key(text: str) -> list[object]:
@@ -28,7 +33,7 @@ class ProjectRepository:
         self.questions_dir.mkdir(parents=True, exist_ok=True)
 
     def init_project(
-        self, name: str, course: str, openai_model: str = "gpt-5.2"
+        self, name: str, course: str, openai_model: str = DEFAULT_OPENAI_MODEL
     ) -> None:
         self.ensure_layout()
         cfg = ProjectConfig(name=name, course=course)

--- a/tests/integration/test_app_ai_config_and_usage.py
+++ b/tests/integration/test_app_ai_config_and_usage.py
@@ -4,19 +4,20 @@ from fastapi.testclient import TestClient
 
 from exam_helper.ai_service import AIService
 from exam_helper.app import create_app
-from exam_helper.models import AIUsageTotals, ChatTurn
+from exam_helper.models import AIUsageTotals, DEFAULT_OPENAI_MODEL
+from exam_helper.models import ChatTurn
 from exam_helper.repository import ProjectRepository
 
 
 def test_home_shows_model_and_usage(tmp_path) -> None:
     repo = ProjectRepository(tmp_path)
-    repo.init_project("Exam", "Physics", openai_model="gpt-5.2")
+    repo.init_project("Exam", "Physics", openai_model=DEFAULT_OPENAI_MODEL)
     app = create_app(tmp_path, openai_key=None)
     client = TestClient(app)
     resp = client.get("/")
     assert resp.status_code == 200
     assert "model:" in resp.text
-    assert "gpt-5.2" in resp.text
+    assert DEFAULT_OPENAI_MODEL in resp.text
 
 
 def test_question_editor_has_chat_workflow_hooks(tmp_path) -> None:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 
 from exam_helper import cli
+from exam_helper.models import DEFAULT_OPENAI_MODEL
 
 
 def test_serve_parser_accepts_positional_path() -> None:
@@ -48,3 +49,11 @@ def test_cmd_serve_uses_path_for_project_root(monkeypatch) -> None:
     assert captured["host"] == "127.0.0.1"
     assert captured["port"] == 9000
     assert captured["log_level"] == "info"
+
+
+def test_init_parser_defaults_openai_model_to_gpt_54() -> None:
+    parser = cli.build_parser()
+
+    args = parser.parse_args(["init", "my-project"])
+
+    assert args.openai_model == DEFAULT_OPENAI_MODEL

--- a/tests/unit/test_models_repository.py
+++ b/tests/unit/test_models_repository.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import yaml
 
-from exam_helper.models import FigureData, Question, QuestionType
+from exam_helper.models import DEFAULT_OPENAI_MODEL, FigureData, Question, QuestionType
 from exam_helper.repository import ProjectRepository
 
 
@@ -60,7 +60,7 @@ def test_project_defaults_include_ai_config(tmp_path: Path) -> None:
     repo = ProjectRepository(tmp_path)
     repo.init_project("Exam", "Physics")
     project = repo.load_project()
-    assert project.ai.model == "gpt-5.2"
+    assert project.ai.model == DEFAULT_OPENAI_MODEL
     assert project.ai.prompts.overall == ""
     assert project.ai.usage.total_tokens == 0
 
@@ -72,7 +72,7 @@ def test_project_load_back_compat_without_ai_block(tmp_path: Path) -> None:
         "name: Exam\ncourse: Physics\n", encoding="utf-8"
     )
     project = repo.load_project()
-    assert project.ai.model == "gpt-5.2"
+    assert project.ai.model == DEFAULT_OPENAI_MODEL
     assert project.ai.usage.total_cost_usd == 0.0
 
 


### PR DESCRIPTION
Fixes #73

- Centralized the default OpenAI model as gpt-5.4
- Updated project init, app defaults, and UI fallbacks to use the shared constant
- Adjusted docs and tests to match the new default

Validation:
- uv run --extra dev pytest -q
- uv run --extra dev black --check .

Risk:
- The app still treats the model string opaquely; reasoning effort remains the API default for gpt-5.4, which is medium.