### PR TITLE
Warn when Pandoc is unavailable during DOCX export

### DIFF
--- a/src/exam_helper/app.py
+++ b/src/exam_helper/app.py
@@ -4,6 +4,7 @@ import json
 import logging
 import re
 import base64
+import shutil
 from hashlib import sha256
 from pathlib import Path
 from typing import Any
@@ -15,7 +16,10 @@ from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel, Field
 
 from exam_helper.ai_service import AIService
-from exam_helper.export_docx import render_project_docx_bytes
+from exam_helper.export_docx import (
+    _PANDOC_MISSING_WARNING,
+    render_project_docx_bytes,
+)
 from exam_helper.models import (
     AIUsageTotals,
     ChatTurn,
@@ -780,6 +784,9 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
         questions = repo.list_questions() if repo.project_file.exists() else []
         project = repo.load_project() if repo.project_file.exists() else None
         export_warning = request.cookies.get("exam_helper_export_warning")
+        pandoc_warning = (
+            _PANDOC_MISSING_WARNING if shutil.which("pandoc") is None else None
+        )
         response = templates.TemplateResponse(
             request,
             "index.html",
@@ -788,6 +795,7 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
                 "project": project,
                 "questions": questions,
                 "export_warning": export_warning,
+                "pandoc_warning": pandoc_warning,
                 "ai_model": (project.ai.model if project else DEFAULT_OPENAI_MODEL),
                 "ai_usage": (project.ai.usage if project else AIUsageTotals()),
                 "ai_prompts": (project.ai.prompts if project else None),

--- a/src/exam_helper/templates/index.html
+++ b/src/exam_helper/templates/index.html
@@ -62,6 +62,9 @@
         </div>
       </div>
     </div>
+    {% if pandoc_warning %}
+    <p class="warning"><strong>Pandoc warning:</strong> {{ pandoc_warning }}</p>
+    {% endif %}
     {% if export_warning %}
     <p class="warning"><strong>Export warning:</strong> {{ export_warning }}</p>
     {% endif %}

--- a/tests/integration/test_app_ai_config_and_usage.py
+++ b/tests/integration/test_app_ai_config_and_usage.py
@@ -20,6 +20,23 @@ def test_home_shows_model_and_usage(tmp_path) -> None:
     assert DEFAULT_OPENAI_MODEL in resp.text
 
 
+def test_home_warns_when_pandoc_is_missing(tmp_path, monkeypatch) -> None:
+    repo = ProjectRepository(tmp_path)
+    repo.init_project("Exam", "Physics")
+    monkeypatch.setattr("exam_helper.app.shutil.which", lambda name: None)
+    app = create_app(tmp_path, openai_key=None)
+    client = TestClient(app)
+
+    resp = client.get("/")
+
+    assert resp.status_code == 200
+    assert "Pandoc warning:" in resp.text
+    assert (
+        "Pandoc not available; DOCX was exported with plain-text math fallback."
+        in resp.text
+    )
+
+
 def test_question_editor_has_chat_workflow_hooks(tmp_path) -> None:
     repo = ProjectRepository(tmp_path)
     repo.init_project("Exam", "Physics")


### PR DESCRIPTION
Fixes #50

- Surface a persistent warning on the home page when pandoc is not installed.
- Keep the existing export warning fallback and add a regression test for the home-page banner.
- Validated with `uv run --extra dev pytest -q` and `uv run --extra dev black --check .`.