### PR TITLE
Improve `serve` help output

### DIFF
--- a/src/exam_helper/cli.py
+++ b/src/exam_helper/cli.py
@@ -14,6 +14,12 @@ from exam_helper.repository import ProjectRepository
 from exam_helper.validation import validate_project
 
 
+class _HelpFormatter(
+    argparse.ArgumentDefaultsHelpFormatter, argparse.RawDescriptionHelpFormatter
+):
+    pass
+
+
 def cmd_init(args: argparse.Namespace) -> int:
     root = Path(args.path)
     repo = ProjectRepository(root)
@@ -76,7 +82,10 @@ def cmd_serve(args: argparse.Namespace) -> int:
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(prog="exam-helper")
+    parser = argparse.ArgumentParser(
+        prog="exam-helper",
+        formatter_class=_HelpFormatter,
+    )
     sub = parser.add_subparsers(dest="command", required=True)
 
     p_init = sub.add_parser("init", help="Initialize a new exam project.")
@@ -86,11 +95,33 @@ def build_parser() -> argparse.ArgumentParser:
     p_init.add_argument("--openai-model", default=DEFAULT_OPENAI_MODEL)
     p_init.set_defaults(func=cmd_init)
 
-    p_serve = sub.add_parser("serve", help="Serve the local web app.")
-    p_serve.add_argument("path", nargs="?", default=".")
+    p_serve = sub.add_parser(
+        "serve",
+        help="Serve the local web app.",
+        formatter_class=_HelpFormatter,
+        description=(
+            "Start the local FastAPI + HTMX app for an exam project directory.\n"
+            "The path should point at the project root containing project.yaml."
+        ),
+        epilog=(
+            "OpenAI key resolution:\n"
+            "  1. --openai-key\n"
+            "  2. EXAM_HELPER_OPENAI_KEY in ~/.env\n"
+        ),
+    )
+    p_serve.add_argument(
+        "path",
+        nargs="?",
+        default=".",
+        help="Path to the exam project directory.",
+    )
     p_serve.add_argument("--host", default="127.0.0.1")
     p_serve.add_argument("--port", type=int, default=8000)
-    p_serve.add_argument("--openai-key", default=None)
+    p_serve.add_argument(
+        "--openai-key",
+        default=None,
+        help="OpenAI API key override.",
+    )
     p_serve.add_argument("-v", "--verbose", action="count", default=0)
     p_serve.set_defaults(func=cmd_serve)
 

--- a/src/exam_helper/cli.py
+++ b/src/exam_helper/cli.py
@@ -122,7 +122,13 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="OpenAI API key override.",
     )
-    p_serve.add_argument("-v", "--verbose", action="count", default=0)
+    p_serve.add_argument(
+        "-v",
+        "--verbose",
+        action="count",
+        default=0,
+        help="Increase logging verbosity; repeat for more detail.",
+    )
     p_serve.set_defaults(func=cmd_serve)
 
     p_validate = sub.add_parser("validate", help="Validate question files.")

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -2,6 +2,8 @@
 
 from pathlib import Path
 
+import pytest
+
 from exam_helper import cli
 from exam_helper.models import DEFAULT_OPENAI_MODEL
 
@@ -20,6 +22,19 @@ def test_serve_parser_defaults_path_to_current_directory() -> None:
     args = parser.parse_args(["serve"])
 
     assert args.path == "."
+
+
+def test_serve_help_mentions_project_path_and_openai_env(capsys) -> None:
+    parser = cli.build_parser()
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["serve", "-h"])
+
+    out = capsys.readouterr().out
+    assert "project.yaml" in out
+    assert "Path to the exam project directory." in out
+    assert "EXAM_HELPER_OPENAI_KEY in ~/.env" in out
+    assert "--openai-key OPENAI_KEY" in out
 
 
 def test_cmd_serve_uses_path_for_project_root(monkeypatch) -> None:


### PR DESCRIPTION
Fixes #32

- Add clearer `serve` command help text and defaults.
- Document the project root path and the `EXAM_HELPER_OPENAI_KEY` fallback in `~/.env`.
- Add regression coverage for the generated help output.

Validation:
- `uv run --extra dev pytest -q tests/unit/test_cli.py`
- `uv run --extra dev pytest -q`
- `uv run --extra dev black --check .`

Remaining risk:
- Help text is still rendered by `argparse`, so formatting can vary slightly across Python versions.