### PR TITLE
Format numeric answers with sig figs

### DIFF
--- a/src/exam_helper/solution_runtime.py
+++ b/src/exam_helper/solution_runtime.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import ast
 import math
 import re
+from decimal import Decimal, ROUND_HALF_UP
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -149,36 +150,72 @@ def _format_value(value: Any) -> str:
     if isinstance(value, bool):
         return str(value)
     if isinstance(value, (int, float)):
-        return _format_numeric_scalar(value)
+        numeric_value = _decimal_from_value(value)
+        if numeric_value is not None:
+            return _format_decimal_with_sig_figs(numeric_value)
+        return str(value)
     if isinstance(value, sp.Basic):
-        if value.is_number and not value.free_symbols:
-            try:
-                return _format_numeric_scalar(float(sp.N(value, 15)))
-            except Exception:
-                pass
+        numeric_value = _decimal_from_value(value)
+        if numeric_value is not None:
+            return _format_decimal_with_sig_figs(numeric_value)
         return sp.sstr(value)
     return str(value)
 
 
-def _format_numeric_scalar(value: float) -> str:
-    if not math.isfinite(value):
-        return str(value)
+def _decimal_from_value(value: Any) -> Decimal | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return Decimal(value)
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            return None
+        return Decimal(str(value))
+    if isinstance(value, sp.Basic):
+        if not value.is_number or value.is_infinite:
+            return None
+        if value.is_Integer:
+            return Decimal(int(value))
+        try:
+            return Decimal(str(sp.N(value, 15)))
+        except Exception:
+            return None
+    return None
 
-    rendered = format(value, ".3g")
-    if "e" not in rendered and "E" not in rendered:
-        return rendered
 
-    match = re.match(r"^([+-]?(?:\d+(?:\.\d*)?|\.\d+))[eE]([+-]?\d+)$", rendered)
-    if match is None:
-        return rendered
-    mantissa, exponent = match.groups()
-    exponent = exponent.lstrip("+")
-    exponent = exponent.lstrip("0") or "0"
-    if exponent.startswith("-"):
-        exponent = "-" + exponent[1:].lstrip("0")
-        if exponent == "-":
-            exponent = "0"
-    return f"{mantissa}e{exponent}"
+def _format_decimal_with_sig_figs(value: Decimal, sig_figs: int = 3) -> str:
+    if value.is_zero():
+        return "0"
+
+    sign = "-" if value.is_signed() else ""
+    abs_value = value.copy_abs()
+
+    if abs_value == abs_value.to_integral_value():
+        return f"{sign}{format(abs_value.to_integral_value(), 'f')}"
+
+    exponent = abs_value.adjusted()
+
+    def _format_scientific(decimal_value: Decimal) -> str:
+        scientific_exponent = decimal_value.copy_abs().adjusted()
+        mantissa = decimal_value.scaleb(-scientific_exponent)
+        mantissa_places = max(sig_figs - 1, 0)
+        quant = Decimal(1).scaleb(-mantissa_places)
+        mantissa = mantissa.quantize(quant, rounding=ROUND_HALF_UP)
+        if mantissa == Decimal(10):
+            mantissa = Decimal(1).quantize(quant, rounding=ROUND_HALF_UP)
+            scientific_exponent += 1
+        return f"{sign}{format(mantissa, 'f')}e{scientific_exponent}"
+
+    if exponent >= 3 or exponent < -3:
+        return _format_scientific(abs_value)
+
+    decimals = max(sig_figs - exponent - 1, 0)
+    quant = Decimal(1).scaleb(-decimals)
+    rounded = abs_value.quantize(quant, rounding=ROUND_HALF_UP)
+    if rounded.adjusted() >= 3 or rounded.adjusted() < -3:
+        return _format_scientific(rounded)
+
+    return f"{sign}{format(rounded, 'f')}"
 
 
 def _line_targets(node: ast.AST) -> list[str]:

--- a/src/exam_helper/solution_runtime.py
+++ b/src/exam_helper/solution_runtime.py
@@ -66,7 +66,7 @@ def render_template_from_values(template: str, values: dict[str, Any]) -> str:
     for key, value in items:
         rendered = re.sub(
             r"\{\{\s*" + re.escape(str(key)) + r"\s*\}\}",
-            str(value),
+            _format_value(value),
             rendered,
         )
     return rendered
@@ -146,9 +146,39 @@ def _evaluate_formula_expression(
 
 
 def _format_value(value: Any) -> str:
+    if isinstance(value, bool):
+        return str(value)
+    if isinstance(value, (int, float)):
+        return _format_numeric_scalar(value)
     if isinstance(value, sp.Basic):
+        if value.is_number and not value.free_symbols:
+            try:
+                return _format_numeric_scalar(float(sp.N(value, 15)))
+            except Exception:
+                pass
         return sp.sstr(value)
     return str(value)
+
+
+def _format_numeric_scalar(value: float) -> str:
+    if not math.isfinite(value):
+        return str(value)
+
+    rendered = format(value, ".3g")
+    if "e" not in rendered and "E" not in rendered:
+        return rendered
+
+    match = re.match(r"^([+-]?(?:\d+(?:\.\d*)?|\.\d+))[eE]([+-]?\d+)$", rendered)
+    if match is None:
+        return rendered
+    mantissa, exponent = match.groups()
+    exponent = exponent.lstrip("+")
+    exponent = exponent.lstrip("0") or "0"
+    if exponent.startswith("-"):
+        exponent = "-" + exponent[1:].lstrip("0")
+        if exponent == "-":
+            exponent = "0"
+    return f"{mantissa}e{exponent}"
 
 
 def _line_targets(node: ast.AST) -> list[str]:

--- a/src/exam_helper/templates/question_form_v2.html
+++ b/src/exam_helper/templates/question_form_v2.html
@@ -121,6 +121,9 @@
         white-space: pre-wrap;
         font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
       }
+      .mc-preview-text {
+        white-space: pre-wrap;
+      }
       .formula-preview--compact {
         min-height: 0;
         display: inline-block;
@@ -480,11 +483,11 @@
           <div class="mc-preview-grid" style="margin-top: 0.8rem;">
             <div class="card preview">
               <strong>MC Preview (Answers)</strong>
-              <div id="mc_preview_answers">{{ mc_preview_answers if question else '' }}</div>
+              <div id="mc_preview_answers" class="mc-preview-text">{{ mc_preview_answers if question else '' }}</div>
             </div>
             <div class="card preview">
               <strong>MC Preview (Answers + Explanations)</strong>
-              <div id="mc_preview_rationale">{{ mc_preview_rationale if question else '' }}</div>
+              <div id="mc_preview_rationale" class="mc-preview-text">{{ mc_preview_rationale if question else '' }}</div>
             </div>
           </div>
           <p class="hint" id="mc_preview_warning">{{ mc_preview_warning if question else '' }}</p>

--- a/src/exam_helper/templates/question_form_v2.html
+++ b/src/exam_helper/templates/question_form_v2.html
@@ -583,6 +583,23 @@
           .replace(/\\\\\((.*?)\\\\\)/gs, (_, inner) => `$${inner}$`);
       }
 
+      function formatTemplateValue(value) {
+        if (typeof value === "number" && Number.isFinite(value)) {
+          let rendered = Number(value).toPrecision(3);
+          if (/e/i.test(rendered)) {
+            rendered = rendered.replace(/e\+?0*(\d+)/i, "e$1");
+            rendered = rendered.replace(/e-0*(\d+)/i, "e-$1");
+          } else {
+            rendered = rendered
+              .replace(/(\.\d*?[1-9])0+$/, "$1")
+              .replace(/\.0+$/, "")
+              .replace(/\.$/, "");
+          }
+          return rendered;
+        }
+        return String(value);
+      }
+
       function normalizeEditorState(state) {
         const next = { ...state };
         next.title = String(next.title || "");
@@ -785,7 +802,7 @@
         let out = templateEl.value || "";
         for (const [k, v] of Object.entries(params)) {
           const re = new RegExp("\\{\\{\\s*" + String(k).replace(/[.*+?^${}()|[\\]\\]/g, "\\$&") + "\\s*\\}\\}", "g");
-          out = out.replace(re, String(v));
+          out = out.replace(re, formatTemplateValue(v));
         }
         promptPreview.innerHTML = marked.parse(normalizeMathDelimitersForPreview(out || ""));
         if (window.MathJax && window.MathJax.typesetPromise) {

--- a/tests/integration/test_app_question_save.py
+++ b/tests/integration/test_app_question_save.py
@@ -143,6 +143,9 @@ def test_new_question_2_page_contains_simplified_editor(tmp_path) -> None:
     assert 'id="calculated_variables_md"' in html
     assert 'id="answer_guidance"' in html
     assert 'id="rendered_answer_md"' in html
+    assert 'id="mc_preview_answers"' in html
+    assert 'id="mc_preview_rationale"' in html
+    assert 'class="mc-preview-text"' in html
     assert 'id="btn_rewrite"' not in html
     assert 'id="btn_generate_answer"' not in html
     assert '<option value="multiple_choice" selected>' in html
@@ -188,6 +191,8 @@ def test_edit_existing_question_save_preserves_legacy_fields(tmp_path) -> None:
     assert 'id="answer_formula_md"' in edit_html
     assert 'id="calculated_variables_md"' in edit_html
     assert 'id="rendered_answer_md"' in edit_html
+    assert 'id="mc_preview_answers"' in edit_html
+    assert 'id="mc_preview_rationale"' in edit_html
 
     save_resp = client.post(
         "/questions/save",

--- a/tests/unit/test_solution_runtime.py
+++ b/tests/unit/test_solution_runtime.py
@@ -42,9 +42,9 @@ def test_answer_formula_success() -> None:
     result = run_answer_formula(
         code, {"v": 2.5}, answer_text_md="v={{v}} m/s", strict=True
     )
-    assert result.calculated_variables_md == "v = 2.5\nanswer = 2.5"
-    assert result.answer_md == "v=2.5 m/s"
-    assert result.final_answer == "2.5"
+    assert result.calculated_variables_md == "v = 2.50\nanswer = 2.50"
+    assert result.answer_md == "v=2.50 m/s"
+    assert result.final_answer == "2.50"
 
 
 def test_answer_formula_formats_numeric_values_compactly() -> None:
@@ -80,6 +80,22 @@ def test_answer_formula_tracks_last_expression() -> None:
     result = run_answer_formula("x = 1\nx + 2", {}, strict=True)
     assert result.calculated_variables_md == "x = 1\nanswer = 3"
     assert result.final_answer == "3"
+
+
+def test_answer_formula_formats_numeric_values_with_sig_figs() -> None:
+    result = run_answer_formula(
+        "x = 0.1\nanswer = 238.28347281",
+        {},
+        strict=True,
+    )
+    assert result.calculated_variables_md == "x = 0.100\nanswer = 238"
+    assert result.final_answer == "238"
+
+
+def test_answer_formula_keeps_text_answers_as_text() -> None:
+    result = run_answer_formula("answer = '0.00000283'", {}, strict=True)
+    assert result.calculated_variables_md == "answer = 0.00000283"
+    assert result.final_answer == "0.00000283"
 
 
 def test_answer_formula_does_not_backfill_answer_after_a_fatal_error() -> None:
@@ -223,6 +239,28 @@ def test_mc_formula_harness_bare_distractor_expression_overrides_seed_answer() -
     )
     assert out.row_previews[1]["content_md"] == "33"
     assert [c.content_md for c in out.choices] == ["33", "55"]
+
+
+def test_mc_formula_harness_formats_numeric_values_with_sig_figs() -> None:
+    out = run_mc_formula_harness(
+        "answer = 0.1",
+        [
+            {"formula_md": "answer = 0.00000283", "rationale_md": "small value"},
+            {"formula_md": "answer = 999.5", "rationale_md": "rounds up"},
+            {"formula_md": "answer = 'text'", "rationale_md": "text distractor"},
+            {"formula_md": "answer = 238.28347281", "rationale_md": "long decimal"},
+        ],
+        {},
+        strict=True,
+    )
+    assert out.correct_answer_md == "0.100"
+    assert [c.content_md for c in out.choices] == [
+        "2.83e-6",
+        "0.100",
+        "238",
+        "1.00e3",
+        "text",
+    ]
 
 
 def test_mc_formula_harness_sorts_text_values_lexicographically() -> None:

--- a/tests/unit/test_solution_runtime.py
+++ b/tests/unit/test_solution_runtime.py
@@ -47,6 +47,30 @@ def test_answer_formula_success() -> None:
     assert result.final_answer == "2.5"
 
 
+def test_answer_formula_formats_numeric_values_compactly() -> None:
+    result = run_answer_formula(
+        "x = 238.28347281\nanswer = x",
+        {},
+        answer_text_md="x={{answer}}",
+        strict=True,
+    )
+    assert result.calculated_variables_md == "x = 238\nanswer = 238"
+    assert result.answer_md == "x=238"
+    assert result.final_answer == "238"
+
+
+def test_answer_formula_uses_scientific_notation_for_small_values() -> None:
+    result = run_answer_formula(
+        "answer = 0.00000283",
+        {},
+        answer_text_md="a={{answer}}",
+        strict=True,
+    )
+    assert result.calculated_variables_md == "answer = 2.83e-6"
+    assert result.answer_md == "a=2.83e-6"
+    assert result.final_answer == "2.83e-6"
+
+
 def test_answer_formula_requires_nonempty_formula() -> None:
     with pytest.raises(SolutionRuntimeError, match="Formula text is empty"):
         run_answer_formula("", {})


### PR DESCRIPTION
Fixes #72

- Format numeric values in solution rendering and template substitution with concise significant-figure output.
- Keep text answers/distractors unchanged.
- Mirror the same numeric formatting in the question editor's prompt preview.

Validation:
- `uv run --extra dev pytest -q`
- `uv run --extra dev black --check .`

Notes:
- Numeric previews now render compactly while preserving text values as text.