### PR TITLE
Indent wrapped MC explanations in preview

### DIFF
--- a/src/exam_helper/templates/question_form_v2.html
+++ b/src/exam_helper/templates/question_form_v2.html
@@ -124,10 +124,14 @@
       .mc-preview-text {
         white-space: pre-wrap;
       }
-      .mc-preview-text > div {
+      .mc-preview-rationale-card {
+        border-left: 4px solid var(--accent);
+        padding-left: 0.9rem;
+      }
+      .mc-preview-rationale-card .mc-preview-text > div {
         display: grid;
-        grid-template-columns: 2.5rem minmax(0, 1fr);
-        column-gap: 0.5rem;
+        grid-template-columns: 3rem minmax(0, 1fr);
+        column-gap: 0.65rem;
         align-items: start;
       }
       .mc-preview-choice-label {
@@ -498,7 +502,7 @@
               <strong>MC Preview (Answers)</strong>
               <div id="mc_preview_answers" class="mc-preview-text">{{ mc_preview_answers if question else '' }}</div>
             </div>
-            <div class="card preview">
+            <div class="card preview mc-preview-rationale-card">
               <strong>MC Preview (Answers + Explanations)</strong>
               <div id="mc_preview_rationale" class="mc-preview-text">{{ mc_preview_rationale if question else '' }}</div>
             </div>

--- a/src/exam_helper/templates/question_form_v2.html
+++ b/src/exam_helper/templates/question_form_v2.html
@@ -124,6 +124,15 @@
       .mc-preview-text {
         white-space: pre-wrap;
       }
+      .mc-preview-text > div {
+        display: grid;
+        grid-template-columns: auto 1fr;
+        gap: 0.35rem;
+        align-items: start;
+      }
+      .mc-preview-text > div > span {
+        min-width: 0;
+      }
       .formula-preview--compact {
         min-height: 0;
         display: inline-block;

--- a/src/exam_helper/templates/question_form_v2.html
+++ b/src/exam_helper/templates/question_form_v2.html
@@ -126,11 +126,15 @@
       }
       .mc-preview-text > div {
         display: grid;
-        grid-template-columns: auto 1fr;
-        gap: 0.35rem;
+        grid-template-columns: 2.5rem minmax(0, 1fr);
+        column-gap: 0.5rem;
         align-items: start;
       }
-      .mc-preview-text > div > span {
+      .mc-preview-choice-label {
+        text-align: right;
+        font-weight: 700;
+      }
+      .mc-preview-choice-content {
         min-width: 0;
       }
       .formula-preview--compact {
@@ -936,7 +940,12 @@
           const rationale = rationaleText
             ? ` - ${marked.parseInline(normalizeMathDelimitersForPreview(rationaleText))}`
             : "";
-          return `<div><strong>${label}.</strong> <span>${content}${rationale}</span></div>`;
+          return (
+            `<div>` +
+            `<span class="mc-preview-choice-label">${label}.</span>` +
+            `<span class="mc-preview-choice-content">${content}${rationale}</span>` +
+            `</div>`
+          );
         }).join("");
         mcPreviewAnswers.innerHTML = previewAnswersHtml;
         mcPreviewRationale.innerHTML = previewRationaleHtml;

--- a/tests/integration/test_app_question_save.py
+++ b/tests/integration/test_app_question_save.py
@@ -193,6 +193,7 @@ def test_edit_existing_question_save_preserves_legacy_fields(tmp_path) -> None:
     assert 'id="rendered_answer_md"' in edit_html
     assert 'id="mc_preview_answers"' in edit_html
     assert 'id="mc_preview_rationale"' in edit_html
+    assert "mc-preview-rationale-card" in edit_html
 
     save_resp = client.post(
         "/questions/save",

--- a/tests/integration/test_browser_question_roundtrip.py
+++ b/tests/integration/test_browser_question_roundtrip.py
@@ -256,10 +256,26 @@ def test_browser_chat_response_updates_visible_mc_rows(tmp_path: Path) -> None:
                             { preview_md: "25.4", warning: "" }
                           ],
                           mc_preview_choices: [
-                            { label: "A", content_md: "22.4", rationale: "" },
-                            { label: "B", content_md: "23.4", rationale: "" },
-                            { label: "C", content_md: "24.4", rationale: "" },
-                            { label: "D", content_md: "25.4", rationale: "" }
+                            {
+                              label: "A",
+                              content_md: "22.4",
+                              rationale: "This explanation is intentionally long so it wraps onto a second line in the preview pane."
+                            },
+                            {
+                              label: "B",
+                              content_md: "23.4",
+                              rationale: "This explanation is intentionally long so it wraps onto a second line in the preview pane."
+                            },
+                            {
+                              label: "C",
+                              content_md: "24.4",
+                              rationale: "This explanation is intentionally long so it wraps onto a second line in the preview pane."
+                            },
+                            {
+                              label: "D",
+                              content_md: "25.4",
+                              rationale: "This explanation is intentionally long so it wraps onto a second line in the preview pane."
+                            }
                           ]
                         });
                     }""")
@@ -284,6 +300,10 @@ def test_browser_chat_response_updates_visible_mc_rows(tmp_path: Path) -> None:
                     "(el) => el.getBoundingClientRect().height"
                 )
                 assert preview_height < 40
+                preview_row_display = page.locator(
+                    "#mc_preview_rationale > div"
+                ).first.evaluate("(el) => getComputedStyle(el).display")
+                assert preview_row_display == "grid"
             finally:
                 browser.close()
     finally:


### PR DESCRIPTION
fix #95

Change summary:
- Give the MC preview rationale rows a fixed label column so wrapped explanations hang under the explanation text instead of the left edge.
- Add a distinct styling block for the "MC Preview (Answers + Explanations)" card so the explanation section is visually separated from the answers-only section.
- Keep the preview row layout in the browser test aligned with the real UI.
- Add a browser regression check for the rendered preview row display mode and wrapped rationale text.