### PR TITLE
Preserve blank-line indentation in DOCX export

### DIFF
--- a/src/exam_helper/export_docx.py
+++ b/src/exam_helper/export_docx.py
@@ -156,7 +156,10 @@ def _build_project_markdown(
 
     for i, q in enumerate(questions, start=1):
         prompt = normalize_markdown_math_delimiters(_render_prompt(q))
-        lines.append(f"{i}. [{q.points} points] {prompt}")
+        prompt_lines = prompt.splitlines() or [""]
+        lines.append(f"{i}. [{q.points} points] {prompt_lines[0]}")
+        for line in prompt_lines[1:]:
+            lines.append(f"   {line}" if line else "   ")
 
         for figure in q.figures:
             try:

--- a/tests/integration/test_export_docx.py
+++ b/tests/integration/test_export_docx.py
@@ -181,6 +181,41 @@ def test_export_docx_uses_a_paren_markers_for_pandoc_mc_lists(
     assert any(p.text == "opt A" for p in doc.paragraphs)
 
 
+def test_export_docx_keeps_prompt_blank_lines_inside_list_item(
+    tmp_path: Path, monkeypatch
+) -> None:
+    repo = ProjectRepository(tmp_path)
+    repo.init_project("Blank Lines", "Physics")
+    q = Question(
+        id="q1",
+        points=5,
+        solution={
+            "question_template_md": "Line 1\n\nLine 2",
+            "typed_solution_md": "Solution line",
+        },
+    )
+    repo.save_question(q)
+
+    def _fake_pandoc(cmd, check, capture_output, text, cwd):
+        md_path = Path(cmd[1])
+        markdown = md_path.read_text(encoding="utf-8")
+        assert "1. [5 points] Line 1" in markdown
+        assert "\n   \n   Line 2" in markdown
+        out_path = Path(cmd[cmd.index("-o") + 1])
+        d = Document()
+        d.add_paragraph("[5 points] Line 1")
+        d.add_paragraph("Line 2")
+        d.save(out_path)
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr("exam_helper.export_docx.subprocess.run", _fake_pandoc)
+    content, warnings = render_project_docx_bytes(tmp_path)
+    assert warnings == []
+
+    doc = Document(io.BytesIO(content))
+    assert any("Line 1" in p.text for p in doc.paragraphs)
+
+
 def test_export_docx_excludes_soft_deleted_questions(tmp_path: Path) -> None:
     repo = ProjectRepository(tmp_path)
     repo.init_project("Exam", "Physics")


### PR DESCRIPTION
Fixes #59

- Keep question prompt blank lines inside the same numbered list item when building the Pandoc markdown, so Word export preserves the question indent.
- Add a regression test that inspects the generated markdown and confirms blank lines are emitted as indented continuation lines.

Validation:
- `uv run --extra dev pytest -q tests/integration/test_export_docx.py`
- `uv run --extra dev black --check src/exam_helper/export_docx.py tests/integration/test_export_docx.py`

Remaining risk:
- This is validated against the markdown fed to Pandoc. The local environment does not have Pandoc installed, so I could not inspect the rendered DOCX output directly here.