### PR TITLE
Add inline favicon

### DIFF
--- a/src/exam_helper/templates/index.html
+++ b/src/exam_helper/templates/index.html
@@ -4,6 +4,10 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{{ "Exam Helper - " ~ project.name if project else "Exam Helper" }}</title>
+    <link
+      rel="icon"
+      href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='14' fill='%230f766e'/%3E%3Cpath d='M20 18h24v8H20zm0 14h24v8H20zm0 14h16v8H20z' fill='white'/%3E%3C/svg%3E"
+    />
     <script src="https://unpkg.com/htmx.org@1.9.12"></script>
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <script>

--- a/src/exam_helper/templates/index.html
+++ b/src/exam_helper/templates/index.html
@@ -6,7 +6,7 @@
     <title>{{ "Exam Helper - " ~ project.name if project else "Exam Helper" }}</title>
     <link
       rel="icon"
-      href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='14' fill='%230f766e'/%3E%3Cpath d='M20 18h24v8H20zm0 14h24v8H20zm0 14h16v8H20z' fill='white'/%3E%3C/svg%3E"
+      href="data:image/svg+xml,%3Csvg%20xmlns=%27http://www.w3.org/2000/svg%27%20viewBox=%270%200%2064%2064%27%3E%3Crect%20width=%2764%27%20height=%2764%27%20rx=%2714%27%20fill=%27%230f766e%27/%3E%3Cpath%20d=%27M20%2018h24v8H20zm0%2014h24v8H20zm0%2014h16v8H20z%27%20fill=%27white%27/%3E%3C/svg%3E"
     />
     <script src="https://unpkg.com/htmx.org@1.9.12"></script>
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>

--- a/src/exam_helper/templates/question_form_v2.html
+++ b/src/exam_helper/templates/question_form_v2.html
@@ -4,6 +4,10 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{% if question %}Question Editor - {{ question.id }}{% if question.title.strip() %} - {{ question.title }}{% endif %}{% else %}Question Editor - New Question{% endif %}</title>
+    <link
+      rel="icon"
+      href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='14' fill='%230f766e'/%3E%3Cpath d='M20 18h24v8H20zm0 14h24v8H20zm0 14h16v8H20z' fill='white'/%3E%3C/svg%3E"
+    />
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/js-yaml@4.1.0/dist/js-yaml.min.js"></script>
     <script>

--- a/tests/integration/test_app_ai_config_and_usage.py
+++ b/tests/integration/test_app_ai_config_and_usage.py
@@ -17,6 +17,7 @@ def test_home_shows_model_and_usage(tmp_path) -> None:
     resp = client.get("/")
     assert resp.status_code == 200
     assert "<title>Exam Helper - Exam</title>" in resp.text
+    assert 'rel="icon"' in resp.text
     assert "model:" in resp.text
     assert DEFAULT_OPENAI_MODEL in resp.text
 
@@ -61,6 +62,7 @@ def test_question_editor_has_chat_workflow_hooks(tmp_path) -> None:
     resp = client.get("/questions/q_edit/edit")
     assert resp.status_code == 200
     assert "<title>Question Editor - q_edit - T</title>" in resp.text
+    assert 'rel="icon"' in resp.text
     assert '<details class="card chat-panel"' in resp.text
     assert "<summary>Chat Assistant</summary>" in resp.text
     assert 'id="chat_thread"' in resp.text


### PR DESCRIPTION
Fixes #76

- Add a tiny inline SVG favicon link to the main and editor templates so the browser stops requesting a missing default favicon.
- Reuse the existing page-rendering tests to confirm the icon link is present on both pages.

Validation:
- `uv run --extra dev pytest -q tests/integration/test_app_ai_config_and_usage.py`
- `uv run --extra dev black --check tests/integration/test_app_ai_config_and_usage.py`

Remaining risk:
- The favicon is embedded as a data URI, which is intentional to avoid adding new static asset plumbing.