### PR TITLE
Log harness run exceptions before 422 response

### DIFF
--- a/src/exam_helper/app.py
+++ b/src/exam_helper/app.py
@@ -970,6 +970,18 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
                 },
             )
         except Exception as ex:
+            logger.exception(
+                "harness.run failed question_id=%s qtype=%s template_len=%s params_keys=%s figures=%s",
+                question_id,
+                q.question_type.value if "q" in locals() else "unknown",
+                (
+                    len((q.solution.question_template_md or "").strip())
+                    if "q" in locals()
+                    else 0
+                ),
+                sorted((q.solution.parameters or {}).keys()) if "q" in locals() else [],
+                [f.id for f in (q.figures or [])] if "q" in locals() else [],
+            )
             return JSONResponse({"ok": False, "error": str(ex)}, status_code=422)
 
     @app.post("/questions/{question_id}/ai/rewrite-and-parameterize")
@@ -1097,6 +1109,18 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
             repo.save_question(q)
             return payload
         except Exception as ex:
+            logger.exception(
+                "harness.run failed question_id=%s qtype=%s template_len=%s params_keys=%s figures=%s",
+                question_id,
+                q.question_type.value if "q" in locals() else "unknown",
+                (
+                    len((q.solution.question_template_md or "").strip())
+                    if "q" in locals()
+                    else 0
+                ),
+                sorted((q.solution.parameters or {}).keys()) if "q" in locals() else [],
+                [f.id for f in (q.figures or [])] if "q" in locals() else [],
+            )
             return JSONResponse({"ok": False, "error": str(ex)}, status_code=422)
 
     @app.post("/questions/{question_id}/ai/generate-mc-distractors")

--- a/src/exam_helper/app.py
+++ b/src/exam_helper/app.py
@@ -926,6 +926,7 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
     @app.post("/questions/{question_id}/ai/chat")
     def ai_chat(question_id: str, payload: ChatPayload = Body(...)) -> dict:
         try:
+            question_for_log = None
             existing = None
             try:
                 existing = repo.get_question(question_id)
@@ -934,12 +935,14 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
             live_question, _, _ = _build_question_from_editor_state(
                 question_id, existing, payload.editor_state
             )
+            question_for_log = live_question
             result = app.state.ai.chat_edit_question(
                 live_question,
                 payload.message,
                 attached_figure_ids=payload.attached_figure_ids,
                 history_keep_count=payload.history_keep_count,
             )
+            question_for_log = result.question
             repo.add_ai_usage(result.usage)
             question = result.question
             _append_chat_turn(
@@ -973,14 +976,26 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
             logger.exception(
                 "harness.run failed question_id=%s qtype=%s template_len=%s params_keys=%s figures=%s",
                 question_id,
-                q.question_type.value if "q" in locals() else "unknown",
                 (
-                    len((q.solution.question_template_md or "").strip())
-                    if "q" in locals()
+                    question_for_log.question_type.value
+                    if question_for_log is not None
+                    else "unknown"
+                ),
+                (
+                    len((question_for_log.solution.question_template_md or "").strip())
+                    if question_for_log is not None
                     else 0
                 ),
-                sorted((q.solution.parameters or {}).keys()) if "q" in locals() else [],
-                [f.id for f in (q.figures or [])] if "q" in locals() else [],
+                (
+                    sorted((question_for_log.solution.parameters or {}).keys())
+                    if question_for_log is not None
+                    else []
+                ),
+                (
+                    [f.id for f in (question_for_log.figures or [])]
+                    if question_for_log is not None
+                    else []
+                ),
             )
             return JSONResponse({"ok": False, "error": str(ex)}, status_code=422)
 

--- a/tests/integration/test_autosave_and_ai_errors.py
+++ b/tests/integration/test_autosave_and_ai_errors.py
@@ -273,11 +273,12 @@ def test_harness_run_logs_exception_before_returning_422(tmp_path, monkeypatch) 
         raise RuntimeError("boom")
 
     records: list[tuple[str, tuple[object, ...], dict[str, object]]] = []
+    app_logger = logging.getLogger("exam_helper.app")
 
-    def _record_exception(self, msg, *args, **kwargs):
+    def _record_exception(msg, *args, **kwargs):
         records.append((msg, args, kwargs))
 
-    monkeypatch.setattr(logging.Logger, "exception", _record_exception)
+    monkeypatch.setattr(app_logger, "exception", _record_exception)
     monkeypatch.setattr("exam_helper.app.run_answer_formula", _boom)
     resp = client.post("/questions/q_harness_error/harness/run")
 

--- a/tests/integration/test_autosave_and_ai_errors.py
+++ b/tests/integration/test_autosave_and_ai_errors.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import json
 
 from fastapi.testclient import TestClient
@@ -234,6 +235,57 @@ def test_harness_run_returns_422_for_collisions(tmp_path) -> None:
     assert resp.status_code == 422
     assert resp.json()["ok"] is False
     assert resp.json()["collisions"]
+
+
+def test_harness_run_logs_exception_before_returning_422(tmp_path, monkeypatch) -> None:
+    repo = ProjectRepository(tmp_path)
+    repo.init_project("Exam", "Physics")
+    app = create_app(tmp_path, openai_key=None)
+    client = TestClient(app)
+    _seed_question(client, "q_harness_error", qtype="multiple_choice")
+    client.post(
+        "/questions/q_harness_error/autosave",
+        json={
+            "title": "T",
+            "question_type": "multiple_choice",
+            "prompt_md": "P",
+            "question_template_md": "P",
+            "solution_parameters_yaml": "{}",
+            "answer_formula_md": "answer = 2",
+            "mc_answer_specs_json": (
+                "["
+                '{"formula_md":"answer = 3","rationale_md":"r"},'
+                '{"formula_md":"answer = 4","rationale_md":"r"},'
+                '{"formula_md":"answer = 5","rationale_md":"r"},'
+                '{"formula_md":"answer = 6","rationale_md":"r"}'
+                "]"
+            ),
+            "distractor_functions_text": "",
+            "choices_yaml": "[]",
+            "typed_solution_md": "",
+            "typed_solution_status": "missing",
+            "figures_json": "[]",
+            "points": 5,
+        },
+    )
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    records: list[tuple[str, tuple[object, ...], dict[str, object]]] = []
+
+    def _record_exception(self, msg, *args, **kwargs):
+        records.append((msg, args, kwargs))
+
+    monkeypatch.setattr(logging.Logger, "exception", _record_exception)
+    monkeypatch.setattr("exam_helper.app.run_answer_formula", _boom)
+    resp = client.post("/questions/q_harness_error/harness/run")
+
+    assert resp.status_code == 422
+    assert resp.json()["ok"] is False
+    assert records
+    assert records[0][0].startswith("harness.run failed question_id=%s")
+    assert records[0][1][0] == "q_harness_error"
 
 
 def test_autosave_updates_mc_formula_preview(tmp_path) -> None:


### PR DESCRIPTION
Fixes #49

- Add exception logging to the `/questions/{question_id}/harness/run` handler before it returns a 422.
- Add a regression test that forces the harness path to raise and confirms the logger is called.

Validation:
- `uv run --extra dev pytest -q tests/integration/test_autosave_and_ai_errors.py -k harness_run`
- `uv run --extra dev black --check src/exam_helper/app.py tests/integration/test_autosave_and_ai_errors.py`

Remaining risk:
- This improves observability for the failing harness request, but it does not sanitize the underlying error source.