### PR TITLE
Load project .env after home .env

### DIFF
--- a/src/exam_helper/cli.py
+++ b/src/exam_helper/cli.py
@@ -106,8 +106,8 @@ def build_parser() -> argparse.ArgumentParser:
         epilog=(
             "OpenAI key resolution:\n"
             "  1. --openai-key\n"
-            "  2. EXAM_HELPER_OPENAI_KEY in ~/.env\n"
-            "  3. EXAM_HELPER_OPENAI_KEY in the project .env path\n"
+            "  2. EXAM_HELPER_OPENAI_KEY in the project .env path\n"
+            "  3. EXAM_HELPER_OPENAI_KEY in ~/.env\n"
         ),
     )
     p_serve.add_argument(

--- a/src/exam_helper/cli.py
+++ b/src/exam_helper/cli.py
@@ -66,7 +66,7 @@ def cmd_serve(args: argparse.Namespace) -> int:
         level = logging.DEBUG
     logging.basicConfig(level=level, format="%(levelname)s:%(name)s:%(message)s")
 
-    key = resolve_openai_api_key(args.openai_key)
+    key = resolve_openai_api_key(args.openai_key, Path(args.path))
     if key:
         print("OpenAI key loaded.")
     else:
@@ -107,6 +107,7 @@ def build_parser() -> argparse.ArgumentParser:
             "OpenAI key resolution:\n"
             "  1. --openai-key\n"
             "  2. EXAM_HELPER_OPENAI_KEY in ~/.env\n"
+            "  3. EXAM_HELPER_OPENAI_KEY in the project .env path\n"
         ),
     )
     p_serve.add_argument(

--- a/src/exam_helper/config.py
+++ b/src/exam_helper/config.py
@@ -13,16 +13,38 @@ class AppConfig(BaseSettings):
     openai_api_key: str | None = Field(default=None, alias="EXAM_HELPER_OPENAI_KEY")
 
 
-def load_home_env() -> dict[str, str]:
-    env_path = Path.home() / ".env"
+def _load_env_file(env_path: Path) -> dict[str, str]:
     if not env_path.exists():
         return {}
     raw = dotenv_values(env_path)
     return {k: v for k, v in raw.items() if isinstance(v, str)}
 
 
-def resolve_openai_api_key(cli_key: str | None) -> str | None:
+def load_home_env() -> dict[str, str]:
+    return _load_env_file(Path.home() / ".env")
+
+
+def load_local_env(project_root: Path | None) -> dict[str, str]:
+    base_path = Path.cwd() if project_root is None else Path(project_root)
+    if base_path.is_file():
+        base_path = base_path.parent
+    resolved = base_path.resolve(strict=False)
+    env: dict[str, str] = {}
+    for ancestor in list(resolved.parents)[::-1] + [resolved]:
+        env.update(_load_env_file(ancestor / ".env"))
+    return env
+
+
+def resolve_openai_api_key(
+    cli_key: str | None, project_root: Path | None = None
+) -> str | None:
     if cli_key:
         return cli_key
     home_env = load_home_env()
-    return home_env.get("EXAM_HELPER_OPENAI_KEY")
+    local_env = load_local_env(project_root)
+    key_name = "EXAM_HELPER_OPENAI_KEY"
+    if key_name in local_env:
+        return local_env[key_name]
+    if key_name in home_env:
+        return home_env[key_name]
+    return None

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -34,6 +34,7 @@ def test_serve_help_mentions_project_path_and_openai_env(capsys) -> None:
     assert "project.yaml" in out
     assert "Path to the exam project directory." in out
     assert "EXAM_HELPER_OPENAI_KEY in ~/.env" in out
+    assert "EXAM_HELPER_OPENAI_KEY in the project .env path" in out
     assert "--openai-key OPENAI_KEY" in out
 
 
@@ -53,7 +54,9 @@ def test_cmd_serve_uses_path_for_project_root(monkeypatch) -> None:
 
     monkeypatch.setattr(cli, "create_app", fake_create_app)
     monkeypatch.setattr(cli.uvicorn, "run", fake_run)
-    monkeypatch.setattr(cli, "resolve_openai_api_key", lambda _: "key")
+    monkeypatch.setattr(
+        cli, "resolve_openai_api_key", lambda key, project_root=None: "key"
+    )
 
     parser = cli.build_parser()
     args = parser.parse_args(["serve", "my-project", "--port", "9000"])

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -19,3 +19,17 @@ def test_home_env_used_when_cli_missing(monkeypatch, tmp_path: Path) -> None:
         "EXAM_HELPER_OPENAI_KEY=from_env\n", encoding="utf-8"
     )
     assert resolve_openai_api_key(None) == "from_env"
+
+
+def test_local_env_overrides_home_env(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+    home = tmp_path / "home"
+    home.mkdir()
+    project_root = tmp_path / "project" / "nested"
+    project_root.mkdir(parents=True)
+    (home / ".env").write_text("EXAM_HELPER_OPENAI_KEY=from_home\n", encoding="utf-8")
+    (project_root.parent / ".env").write_text(
+        "EXAM_HELPER_OPENAI_KEY=from_local\n", encoding="utf-8"
+    )
+
+    assert resolve_openai_api_key(None, project_root) == "from_local"


### PR DESCRIPTION
Fixes #33

- Load `~/.env` first and then overlay `.env` files from the current project path so local values override home values.
- Thread the project path through `serve` so the resolver can look in the project tree.
- Add tests for the lookup order and CLI help text.

Validation:
- `uv run --extra dev pytest -q tests/unit/test_config.py tests/unit/test_cli.py`
- `uv run --extra dev black --check src/exam_helper/config.py src/exam_helper/cli.py tests/unit/test_config.py tests/unit/test_cli.py`

Remaining risk:
- The lookup walks the path ancestors from root to the provided project directory; that matches the intended fallback order, but it is a behavioral change from the previous home-only implementation.