### PR TITLE
Clarify SymPy power syntax in answer prompt

### DIFF
--- a/src/exam_helper/prompt_templates.yaml
+++ b/src/exam_helper/prompt_templates.yaml
@@ -31,6 +31,7 @@ actions:
       If the final line assigns a new variable, set answer to that same value.
       If you create an answer variable, do not overwrite it.
       Do not wrap the expressions in a solve() function.
+      Use ** for powers in SymPy; write x**2, not x^2.
       If LaTeX-style backslashes are needed inside Python string literals, escape them (for example \\theta, \\(x\\)).
       Do not include any prose before or after the JSON object.
     user_prompt_template: |

--- a/tests/unit/test_prompt_catalog.py
+++ b/tests/unit/test_prompt_catalog.py
@@ -29,6 +29,7 @@ def test_prompt_catalog_builds_answer_formula_prompt() -> None:
     bundle = catalog.compose(action="generate_answer_formula", question=q)
     assert "Answer Formula (SymPy):" in bundle.user_prompt
     assert "Answer Text (Markdown):" in bundle.user_prompt
+    assert "Use ** for powers in SymPy" in bundle.system_prompt
 
 
 def test_prompt_catalog_applies_overall_and_rewrite_override() -> None:


### PR DESCRIPTION
Fixes #80

- Add an explicit SymPy exponent reminder to the answer-formula system prompt so the LLM uses `**` instead of `^`.
- Add a prompt-catalog unit test to lock in that instruction.

Validation:
- `uv run --extra dev pytest -q tests/unit/test_prompt_catalog.py`
- `uv run --extra dev black --check tests/unit/test_prompt_catalog.py`

Remaining risk:
- This is prompt guidance rather than a runtime validator, so it reduces but does not eliminate malformed SymPy output from the model.