### PR TITLE
Click on image to see full sized image

### DIFF
--- a/src/exam_helper/templates/question_form_v2.html
+++ b/src/exam_helper/templates/question_form_v2.html
@@ -767,13 +767,13 @@
         return qid ? `/questions/${encodeURIComponent(qid)}/${encodeURIComponent(figureId)}` : "#";
       }
 
-      function figurePreviewSrc(figure) {
+      function figurePreviewSrc(figure, fallbackId = "") {
         const mimeType = String(figure?.mime_type || "image/png");
         const dataBase64 = String(figure?.data_base64 || "");
         if (dataBase64) {
           return `data:${mimeType};base64,${dataBase64}`;
         }
-        const figureId = String(figure?.id || "");
+        const figureId = String(figure?.id || fallbackId || "");
         return figureId ? figureUrl(figureId) : "#";
       }
 
@@ -791,7 +791,7 @@
           return (
             `<div class="figure-item" data-figure-idx="${idx}">` +
             `<button type="button" class="figure-preview-button" data-open-figure="${idx}" aria-label="Open full-size preview of ${figureId}">` +
-            `<img src="${escapeHtml(figurePreviewSrc(figure))}" alt="${figureId}" />` +
+            `<img src="${escapeHtml(figurePreviewSrc(figure, figure.id || `fig_${idx + 1}`))}" alt="${figureId}" />` +
             `</button>` +
             `<div><strong>${figureId}</strong><div class="figure-meta">${mimeType} · ${dataSize} base64 chars</div><div class="figure-meta">${caption || "No caption"}</div></div>` +
             `<button type="button" class="btn btn-secondary" data-remove-figure="${idx}">Remove</button>` +
@@ -822,7 +822,7 @@
         const mimeType = String(figure.mime_type || "image/png");
         const dataSize = String((figure.data_base64 || "").length);
         figureModalTitleEl.textContent = figureId;
-        figureModalImageEl.src = figurePreviewSrc(figure);
+        figureModalImageEl.src = figurePreviewSrc(figure, figureId);
         figureModalImageEl.alt = caption ? `${figureId}: ${caption}` : figureId;
         figureModalMetaEl.textContent = `${mimeType} · ${dataSize} base64 chars${caption ? ` · ${caption}` : ""}`;
         figureModalLastFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null;

--- a/src/exam_helper/templates/question_form_v2.html
+++ b/src/exam_helper/templates/question_form_v2.html
@@ -558,7 +558,23 @@
           <button type="button" class="btn btn-secondary" id="btn_add_figure">Add Image File</button>
           <input type="file" id="figure_file_input" accept="image/*" multiple style="display:none;" />
           <input type="hidden" id="figures_json" name="figures_json" value='{{ figures_json }}' />
-          <div id="figures_preview"></div>
+          <div id="figures_preview">
+            {% if question and question.figures %}
+              {% for figure in question.figures %}
+              <div class="figure-item" data-figure-idx="{{ loop.index0 }}">
+                <button type="button" class="figure-preview-button" data-open-figure="{{ loop.index0 }}" aria-label="Open full-size preview of {{ figure.id }}">
+                  <img src="data:{{ figure.mime_type }};base64,{{ figure.data_base64 }}" alt="{{ figure.id }}" />
+                </button>
+                <div>
+                  <strong>{{ figure.id }}</strong>
+                  <div class="figure-meta">{{ figure.mime_type }} · {{ figure.data_base64 | length }} base64 chars</div>
+                  <div class="figure-meta">{{ figure.caption or "No caption" }}</div>
+                </div>
+                <button type="button" class="btn btn-secondary" data-remove-figure="{{ loop.index0 }}">Remove</button>
+              </div>
+              {% endfor %}
+            {% endif %}
+          </div>
         </div>
         <div id="figure_modal" class="figure-modal" aria-hidden="true">
           <div class="figure-modal__backdrop" data-close-figure-modal></div>

--- a/src/exam_helper/templates/question_form_v2.html
+++ b/src/exam_helper/templates/question_form_v2.html
@@ -563,7 +563,7 @@
               {% for figure in question.figures %}
               <div class="figure-item" data-figure-idx="{{ loop.index0 }}">
                 <button type="button" class="figure-preview-button" data-open-figure="{{ loop.index0 }}" aria-label="Open full-size preview of {{ figure.id }}">
-                  <img src="data:{{ figure.mime_type }};base64,{{ figure.data_base64 }}" alt="{{ figure.id }}" />
+                  <img src="/questions/{{ question.id }}/{{ figure.id }}" alt="{{ figure.id }}" />
                 </button>
                 <div>
                   <strong>{{ figure.id }}</strong>

--- a/src/exam_helper/templates/question_form_v2.html
+++ b/src/exam_helper/templates/question_form_v2.html
@@ -182,9 +182,68 @@
         border-radius: 10px;
         border: 1px solid #eee4d2;
       }
+      .figure-preview-button {
+        display: block;
+        width: 100%;
+        border: 0;
+        padding: 0;
+        background: none;
+        text-align: left;
+        cursor: zoom-in;
+      }
+      .figure-preview-button img {
+        cursor: zoom-in;
+      }
       .figure-meta {
         font-size: 0.92rem;
         color: var(--muted);
+      }
+      .figure-modal {
+        position: fixed;
+        inset: 0;
+        display: none;
+        align-items: center;
+        justify-content: center;
+        padding: 1rem;
+        z-index: 60;
+      }
+      .figure-modal.is-open {
+        display: flex;
+      }
+      .figure-modal__backdrop {
+        position: absolute;
+        inset: 0;
+        background: rgba(41, 30, 18, 0.78);
+        backdrop-filter: blur(4px);
+      }
+      .figure-modal__panel {
+        position: relative;
+        z-index: 1;
+        width: min(96vw, 1000px);
+        max-height: 90vh;
+        overflow: auto;
+        background: var(--surface);
+        border: 1px solid var(--line);
+        border-radius: 20px;
+        box-shadow: 0 20px 60px rgba(41, 30, 18, 0.35);
+        padding: 1rem;
+        display: grid;
+        gap: 0.75rem;
+      }
+      .figure-modal__panel img {
+        width: 100%;
+        max-height: 76vh;
+        object-fit: contain;
+        background: #fff;
+        border-radius: 14px;
+        border: 1px solid #eadfcf;
+      }
+      .figure-modal__meta {
+        color: var(--muted);
+        font-size: 0.95rem;
+      }
+      .figure-modal__close {
+        justify-self: end;
       }
       .mc-preview-grid {
         display: grid;
@@ -501,6 +560,15 @@
           <input type="hidden" id="figures_json" name="figures_json" value='{{ figures_json }}' />
           <div id="figures_preview"></div>
         </div>
+        <div id="figure_modal" class="figure-modal" aria-hidden="true">
+          <div class="figure-modal__backdrop" data-close-figure-modal></div>
+          <div class="figure-modal__panel" role="dialog" aria-modal="true" aria-labelledby="figure_modal_title">
+            <button type="button" class="btn btn-secondary figure-modal__close" id="figure_modal_close" data-close-figure-modal aria-label="Close full-size figure preview">Close</button>
+            <h3 id="figure_modal_title">Figure preview</h3>
+            <img id="figure_modal_image" alt="" />
+            <div id="figure_modal_meta" class="figure-modal__meta"></div>
+          </div>
+        </div>
 
         <div class="actions">
           <button type="submit" class="btn">Save and Return</button>
@@ -533,6 +601,11 @@
       const figuresInput = document.getElementById("figures_json");
       const figuresPreviewEl = document.getElementById("figures_preview");
       const figuresSectionEl = document.getElementById("figures_section");
+      const figureModalEl = document.getElementById("figure_modal");
+      const figureModalTitleEl = document.getElementById("figure_modal_title");
+      const figureModalImageEl = document.getElementById("figure_modal_image");
+      const figureModalMetaEl = document.getElementById("figure_modal_meta");
+      const figureModalCloseEl = document.getElementById("figure_modal_close");
       const addFigureBtn = document.getElementById("btn_add_figure");
       const figureFileInput = document.getElementById("figure_file_input");
       const promptPreview = document.getElementById("prompt_preview");
@@ -551,6 +624,7 @@
       let editorState = {{ editor_state | tojson }};
       let autosaveTimer = null;
       let pendingChatFigureIds = [];
+      let figureModalLastFocus = null;
 
       function setStatus(text, cls) {
         saveStatus.textContent = text;
@@ -690,12 +764,45 @@
           const dataSize = String((figure.data_base64 || "").length);
           return (
             `<div class="figure-item" data-figure-idx="${idx}">` +
+            `<button type="button" class="figure-preview-button" data-open-figure="${idx}" aria-label="Open full-size preview of ${figureId}">` +
             `<img src="${figureUrl(figure.id || `fig_${idx + 1}`)}" alt="${figureId}" onerror="this.style.display='none';" />` +
+            `</button>` +
             `<div><strong>${figureId}</strong><div class="figure-meta">${mimeType} · ${dataSize} base64 chars</div><div class="figure-meta">${caption || "No caption"}</div></div>` +
             `<button type="button" class="btn btn-secondary" data-remove-figure="${idx}">Remove</button>` +
             `</div>`
           );
         }).join("");
+      }
+
+      function closeFigureModal() {
+        figureModalEl.classList.remove("is-open");
+        figureModalEl.setAttribute("aria-hidden", "true");
+        figureModalImageEl.removeAttribute("src");
+        figureModalImageEl.alt = "";
+        figureModalTitleEl.textContent = "Figure preview";
+        figureModalMetaEl.textContent = "";
+        if (figureModalLastFocus && typeof figureModalLastFocus.focus === "function") {
+          figureModalLastFocus.focus();
+        }
+        figureModalLastFocus = null;
+      }
+
+      function openFigureModal(idx) {
+        const figures = parseFigures();
+        if (!Number.isInteger(idx) || idx < 0 || idx >= figures.length) return;
+        const figure = figures[idx] || {};
+        const figureId = String(figure.id || `fig_${idx + 1}`);
+        const caption = String(figure.caption || "");
+        const mimeType = String(figure.mime_type || "image/png");
+        const dataSize = String((figure.data_base64 || "").length);
+        figureModalTitleEl.textContent = figureId;
+        figureModalImageEl.src = figureUrl(figureId);
+        figureModalImageEl.alt = caption ? `${figureId}: ${caption}` : figureId;
+        figureModalMetaEl.textContent = `${mimeType} · ${dataSize} base64 chars${caption ? ` · ${caption}` : ""}`;
+        figureModalLastFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+        figureModalEl.classList.add("is-open");
+        figureModalEl.setAttribute("aria-hidden", "false");
+        figureModalCloseEl.focus();
       }
 
       function insertTemplateAtCursor(text, fallbackAppend = true) {
@@ -1137,6 +1244,12 @@
       });
 
       figuresPreviewEl.addEventListener("click", (event) => {
+        const openBtn = event.target.closest("[data-open-figure]");
+        if (openBtn) {
+          const openIdx = Number(openBtn.getAttribute("data-open-figure"));
+          openFigureModal(openIdx);
+          return;
+        }
         const btn = event.target.closest("[data-remove-figure]");
         if (!btn) return;
         const idx = Number(btn.getAttribute("data-remove-figure"));
@@ -1208,6 +1321,18 @@
         }
       });
 
+      figureModalEl.addEventListener("click", (event) => {
+        if (event.target instanceof Element && event.target.closest("[data-close-figure-modal]")) {
+          closeFigureModal();
+        }
+      });
+
+      document.addEventListener("keydown", (event) => {
+        if (event.key === "Escape" && figureModalEl.classList.contains("is-open")) {
+          closeFigureModal();
+        }
+      });
+
       form.addEventListener("submit", () => {
         collectEditorStateFromDOM();
         setStatus("Saving...", "warn");
@@ -1242,6 +1367,7 @@
       renderMarkdownSurface(renderedAnswerEl, renderedAnswerEl.textContent || "");
       updateMCVisibility();
       renderFiguresPreview();
+      closeFigureModal();
       renderChatHistory();
       setChatBusy(false);
       renderPendingChatAttachments();

--- a/src/exam_helper/templates/question_form_v2.html
+++ b/src/exam_helper/templates/question_form_v2.html
@@ -751,6 +751,16 @@
         return qid ? `/questions/${encodeURIComponent(qid)}/${encodeURIComponent(figureId)}` : "#";
       }
 
+      function figurePreviewSrc(figure) {
+        const mimeType = String(figure?.mime_type || "image/png");
+        const dataBase64 = String(figure?.data_base64 || "");
+        if (dataBase64) {
+          return `data:${mimeType};base64,${dataBase64}`;
+        }
+        const figureId = String(figure?.id || "");
+        return figureId ? figureUrl(figureId) : "#";
+      }
+
       function renderFiguresPreview() {
         const figures = parseFigures();
         if (!figures.length) {
@@ -765,7 +775,7 @@
           return (
             `<div class="figure-item" data-figure-idx="${idx}">` +
             `<button type="button" class="figure-preview-button" data-open-figure="${idx}" aria-label="Open full-size preview of ${figureId}">` +
-            `<img src="${figureUrl(figure.id || `fig_${idx + 1}`)}" alt="${figureId}" onerror="this.style.display='none';" />` +
+            `<img src="${escapeHtml(figurePreviewSrc(figure))}" alt="${figureId}" />` +
             `</button>` +
             `<div><strong>${figureId}</strong><div class="figure-meta">${mimeType} · ${dataSize} base64 chars</div><div class="figure-meta">${caption || "No caption"}</div></div>` +
             `<button type="button" class="btn btn-secondary" data-remove-figure="${idx}">Remove</button>` +
@@ -796,7 +806,7 @@
         const mimeType = String(figure.mime_type || "image/png");
         const dataSize = String((figure.data_base64 || "").length);
         figureModalTitleEl.textContent = figureId;
-        figureModalImageEl.src = figureUrl(figureId);
+        figureModalImageEl.src = figurePreviewSrc(figure);
         figureModalImageEl.alt = caption ? `${figureId}: ${caption}` : figureId;
         figureModalMetaEl.textContent = `${mimeType} · ${dataSize} base64 chars${caption ? ` · ${caption}` : ""}`;
         figureModalLastFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null;

--- a/tests/integration/test_app_question_save.py
+++ b/tests/integration/test_app_question_save.py
@@ -207,7 +207,7 @@ def test_edit_existing_question_save_preserves_legacy_fields(tmp_path) -> None:
     assert 'id="rendered_answer_md"' in edit_html
     assert 'id="mc_preview_answers"' in edit_html
     assert 'id="mc_preview_rationale"' in edit_html
-    assert "data:image/png;base64," in edit_html
+    assert "/questions/legacy-editor/fig_1" in edit_html
     assert 'data-open-figure="0"' in edit_html
 
     save_resp = client.post(

--- a/tests/integration/test_app_question_save.py
+++ b/tests/integration/test_app_question_save.py
@@ -155,6 +155,11 @@ def test_new_question_2_page_contains_simplified_editor(tmp_path) -> None:
 def test_edit_existing_question_save_preserves_legacy_fields(tmp_path) -> None:
     repo = ProjectRepository(tmp_path)
     repo.init_project("Exam", "Physics")
+    fig_b64 = (
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8"
+        "/w8AAgMBgU7Y5e0AAAAASUVORK5CYII="
+    )
+    fig_sha = hashlib.sha256(base64.b64decode(fig_b64.encode("ascii"))).hexdigest()
     question_path = tmp_path / "questions" / "legacy-editor.yaml"
     question_path.write_text(
         yaml.safe_dump(
@@ -167,6 +172,15 @@ def test_edit_existing_question_save_preserves_legacy_fields(tmp_path) -> None:
                 "solution_md": "Old solution",
                 "typed_solution_md": "Typed solution",
                 "typed_solution_status": "draft",
+                "figures": [
+                    {
+                        "id": "fig_1",
+                        "mime_type": "image/png",
+                        "data_base64": fig_b64,
+                        "sha256": fig_sha,
+                        "caption": "tiny figure",
+                    }
+                ],
                 "answer_function": "def answer(student_answer, context):\n    return True",
                 "distractors": ["wrong 1", "wrong 2"],
                 "checker": {
@@ -193,6 +207,8 @@ def test_edit_existing_question_save_preserves_legacy_fields(tmp_path) -> None:
     assert 'id="rendered_answer_md"' in edit_html
     assert 'id="mc_preview_answers"' in edit_html
     assert 'id="mc_preview_rationale"' in edit_html
+    assert "data:image/png;base64," in edit_html
+    assert 'data-open-figure="0"' in edit_html
 
     save_resp = client.post(
         "/questions/save",

--- a/tests/integration/test_browser_question_roundtrip.py
+++ b/tests/integration/test_browser_question_roundtrip.py
@@ -377,6 +377,11 @@ def test_browser_figure_preview_modal_opens_and_closes(tmp_path: Path) -> None:
 
                 preview_button = page.locator("[data-open-figure='0']")
                 assert preview_button.is_visible()
+                assert (
+                    preview_button.locator("img")
+                    .get_attribute("src")
+                    .startswith("data:image/png;base64,")
+                )
                 preview_button.click()
 
                 modal = page.locator("#figure_modal")
@@ -388,6 +393,19 @@ def test_browser_figure_preview_modal_opens_and_closes(tmp_path: Path) -> None:
                 page.locator("#figure_modal .figure-modal__backdrop").click()
                 assert modal.get_attribute("aria-hidden") == "true"
 
+                page.get_by_role("button", name="Save and Return").click()
+                page.wait_for_url(base_url + "/")
+
+                page.get_by_role("link", name="Edit").click()
+                page.wait_for_url(base_url + "/questions/q_figure/edit")
+
+                preview_button = page.locator("[data-open-figure='0']")
+                assert preview_button.is_visible()
+                assert (
+                    preview_button.locator("img")
+                    .get_attribute("src")
+                    .startswith("data:image/png;base64,")
+                )
                 preview_button.click()
                 page.locator("#figure_modal_close").click()
                 assert modal.get_attribute("aria-hidden") == "true"

--- a/tests/integration/test_browser_question_roundtrip.py
+++ b/tests/integration/test_browser_question_roundtrip.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import base64
+import hashlib
+import json
 import socket
 import subprocess
 import sys
@@ -284,6 +287,110 @@ def test_browser_chat_response_updates_visible_mc_rows(tmp_path: Path) -> None:
                     "(el) => el.getBoundingClientRect().height"
                 )
                 assert preview_height < 40
+            finally:
+                browser.close()
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=10)
+
+
+def test_browser_figure_preview_modal_opens_and_closes(tmp_path: Path) -> None:
+    pytest.importorskip("playwright.sync_api")
+    from playwright.sync_api import Error as PlaywrightError, sync_playwright
+
+    repo = ProjectRepository(tmp_path)
+    repo.init_project("Figure Exam", "Physics 1")
+    port = _free_port()
+    base_url = f"http://127.0.0.1:{port}"
+
+    # 1x1 transparent PNG
+    b64 = (
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8"
+        "/w8AAgMBgU7Y5e0AAAAASUVORK5CYII="
+    )
+    sha256 = hashlib.sha256(base64.b64decode(b64.encode("ascii"))).hexdigest()
+    figures_json = json.dumps(
+        [
+            {
+                "id": "fig_1",
+                "mime_type": "image/png",
+                "data_base64": b64,
+                "sha256": sha256,
+                "caption": "tiny figure",
+            }
+        ]
+    )
+
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "exam_helper.cli",
+            "serve",
+            str(tmp_path),
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    try:
+        _wait_for_server(base_url + "/", proc)
+        seed = httpx.post(
+            base_url + "/questions/save",
+            data={
+                "question_id": "q_figure",
+                "title": "Figure Test",
+                "question_type": "free_response",
+                "question_template_md": "Look at <figure fig_1>.",
+                "solution_parameters_yaml": "{}",
+                "answer_formula_md": "answer = 1",
+                "answer_guidance": "",
+                "mc_options_guidance": "",
+                "distractor_functions_text": "",
+                "choices_yaml": "[]",
+                "typed_solution_md": "",
+                "typed_solution_status": "fresh",
+                "figures_json": figures_json,
+                "points": 5,
+            },
+            follow_redirects=False,
+            timeout=5.0,
+        )
+        assert seed.status_code == 303
+        with sync_playwright() as p:
+            try:
+                browser = p.chromium.launch(headless=True)
+            except PlaywrightError as exc:
+                pytest.skip(f"Chromium is not available: {exc}")
+            try:
+                page = browser.new_page()
+                page.goto(base_url + "/questions/q_figure/edit")
+                page.wait_for_url(base_url + "/questions/q_figure/edit")
+
+                preview_button = page.locator("[data-open-figure='0']")
+                assert preview_button.is_visible()
+                preview_button.click()
+
+                modal = page.locator("#figure_modal")
+                assert modal.get_attribute("aria-hidden") == "false"
+                assert page.locator("#figure_modal_title").inner_text() == "fig_1"
+                assert "tiny figure" in page.locator("#figure_modal_meta").inner_text()
+                assert modal.locator("#figure_modal_image").get_attribute("src")
+
+                page.locator("#figure_modal .figure-modal__backdrop").click()
+                assert modal.get_attribute("aria-hidden") == "true"
+
+                preview_button.click()
+                page.locator("#figure_modal_close").click()
+                assert modal.get_attribute("aria-hidden") == "true"
             finally:
                 browser.close()
     finally:


### PR DESCRIPTION
fix #44

Change summary:
- Add a clickable figure preview in the question editor image tray.
- Render thumbnails from the embedded base64 data so they work before and after saving.
- Also server-render the saved figures on the edit page so thumbnails are visible immediately on reload, before JS hydrates the tray.
- Open the figure in an in-page modal with a backdrop and close button.
- Allow dismissal by clicking outside the dialog or pressing Escape.
- Add regression coverage for the open/close flow and the saved/reopened figure list.