### PR TITLE
Send Figure Info In Prompt

### DIFF
--- a/src/exam_helper/ai_service.py
+++ b/src/exam_helper/ai_service.py
@@ -67,6 +67,8 @@ class AIService:
         question_type: str = "free_response"
         points: int = 5
         mc_options_guidance: str = ""
+        figure_ids: list[str] = Field(default_factory=list)
+        figure_summaries: list[str] = Field(default_factory=list)
         question_template_md: str = ""
         solution_parameters_yaml: str = "{}"
         answer_formula_md: str = ""
@@ -230,6 +232,23 @@ class AIService:
         return items
 
     @staticmethod
+    def _figure_summaries(question: Question) -> list[str]:
+        summaries: list[str] = []
+        for fig in question.figures:
+            caption = (fig.caption or fig.id or "").strip() or fig.id
+            summaries.append(f"{fig.id}: {caption} ({fig.mime_type})")
+        return summaries
+
+    @classmethod
+    def _figure_prompt_text(cls, question: Question) -> str:
+        summaries = cls._figure_summaries(question)
+        if not summaries:
+            return ""
+        return "Figures associated with this question:\n" + "\n".join(
+            f"- {item}" for item in summaries
+        )
+
+    @staticmethod
     def _editor_state_for_question(
         question: Question,
     ) -> "AIService.QuestionEditorState":
@@ -261,6 +280,8 @@ class AIService:
             question_type=question.question_type.value,
             points=question.points,
             mc_options_guidance=question.mc_options_guidance,
+            figure_ids=[fig.id for fig in question.figures],
+            figure_summaries=AIService._figure_summaries(question),
             question_template_md=question.solution.question_template_md,
             solution_parameters_yaml=_dump_parameters(question.solution.parameters),
             answer_formula_md=question.solution.answer_formula_md,
@@ -680,6 +701,9 @@ class AIService:
                 ),
             }
         ]
+        figure_prompt_text = self._figure_prompt_text(working)
+        if figure_prompt_text:
+            user_content.append({"type": "input_text", "text": figure_prompt_text})
         if attached_ids:
             user_content.append(
                 {

--- a/src/exam_helper/ai_service.py
+++ b/src/exam_helper/ai_service.py
@@ -235,6 +235,8 @@ class AIService:
     def _figure_summaries(question: Question) -> list[str]:
         summaries: list[str] = []
         for fig in question.figures:
+            # Use author-provided caption first, then fall back to the figure id.
+            # This keeps the prompt stable without a second image-summary AI call.
             caption = (fig.caption or fig.id or "").strip() or fig.id
             summaries.append(f"{fig.id}: {caption} ({fig.mime_type})")
         return summaries

--- a/src/exam_helper/ai_service.py
+++ b/src/exam_helper/ai_service.py
@@ -699,7 +699,8 @@ class AIService:
                     "Persisted recent chat history:\n"
                     f"{history_text}\n\n"
                     f"Current author request:\n{user_message.strip()}\n\n"
-                    "Only images attached to this turn are included below."
+                    "Figure metadata and summaries are included below. "
+                    "Only image bytes explicitly attached to this turn are included below."
                 ),
             }
         ]

--- a/tests/unit/test_ai_service.py
+++ b/tests/unit/test_ai_service.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import base64
+import hashlib
+
 from exam_helper.ai_service import AIService
-from exam_helper.models import Question
+from exam_helper.models import FigureData, Question
 
 
 class _FakeResponses:
@@ -282,6 +285,63 @@ def test_ai_service_chat_edit_question_uses_tool_calls(monkeypatch) -> None:
         "question_template_md",
     ]
     assert out.warnings == ["Validated the deterministic answer formula."]
+
+
+def test_ai_service_chat_edit_question_includes_figure_metadata_in_prompt(
+    monkeypatch,
+) -> None:
+    from exam_helper import ai_service as mod
+
+    class _RecordingResponses:
+        def __init__(self):
+            self.calls = []
+
+        def create(self, **kwargs):
+            self.calls.append(kwargs)
+
+            class R:
+                pass
+
+            r = R()
+            r.output_text = '{"assistant_message":"Updated.","warnings":[]}'
+            r.output = []
+            r.id = "resp_1"
+            return r
+
+    class _RecordingClient:
+        def __init__(self):
+            self.responses = _RecordingResponses()
+
+    recording_client = _RecordingClient()
+    monkeypatch.setattr(mod, "OpenAI", lambda api_key: recording_client)
+    svc = AIService(api_key="k")
+
+    b64 = (
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8"
+        "/w8AAgMBgU7Y5e0AAAAASUVORK5CYII="
+    )
+    fig = FigureData(
+        id="fig_1",
+        mime_type="image/png",
+        data_base64=b64,
+        sha256=hashlib.sha256(base64.b64decode(b64.encode("ascii"))).hexdigest(),
+        caption="small diagram",
+    )
+    q = Question(id="q1", title="Original")
+    q.figures = [fig]
+
+    out = svc.chat_edit_question(q, "rewrite this")
+
+    assert out.assistant_message == "Updated."
+    prompt_text = "\n".join(
+        item["text"]
+        for item in recording_client.responses.calls[0]["input"][1]["content"]
+        if item.get("type") == "input_text"
+    )
+    assert "Figures associated with this question:" in prompt_text
+    assert "fig_1: small diagram (image/png)" in prompt_text
+    assert '"figure_ids"' in prompt_text
+    assert "fig_1" in prompt_text
 
 
 def test_ai_service_chat_edit_question_truncates_history_by_requested_count(

--- a/tests/unit/test_ai_service.py
+++ b/tests/unit/test_ai_service.py
@@ -342,6 +342,8 @@ def test_ai_service_chat_edit_question_includes_figure_metadata_in_prompt(
     assert "fig_1: small diagram (image/png)" in prompt_text
     assert '"figure_ids"' in prompt_text
     assert "fig_1" in prompt_text
+    assert '"figure_summaries"' in prompt_text
+    assert "small diagram" in prompt_text
 
 
 def test_ai_service_chat_edit_question_truncates_history_by_requested_count(

--- a/tests/unit/test_ai_service.py
+++ b/tests/unit/test_ai_service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 import hashlib
+import json
 
 from exam_helper.ai_service import AIService
 from exam_helper.models import FigureData, Question
@@ -338,12 +339,17 @@ def test_ai_service_chat_edit_question_includes_figure_metadata_in_prompt(
         for item in recording_client.responses.calls[0]["input"][1]["content"]
         if item.get("type") == "input_text"
     )
+    state_json = prompt_text.split("Current editor state:\n", 1)[1].split(
+        "\n\nPersisted recent chat history:\n", 1
+    )[0]
+    state = json.loads(state_json)
     assert "Figures associated with this question:" in prompt_text
     assert "fig_1: small diagram (image/png)" in prompt_text
     assert '"figure_ids"' in prompt_text
     assert "fig_1" in prompt_text
     assert '"figure_summaries"' in prompt_text
     assert "small diagram" in prompt_text
+    assert state["figure_summaries"] == ["fig_1: small diagram (image/png)"]
 
 
 def test_ai_service_chat_edit_question_truncates_history_by_requested_count(


### PR DESCRIPTION
fix #71

Change summary:
- Include figure IDs and short figure summaries in the AI chat editor state.
- Add a figure summary block to the user prompt so the model sees associated figures even when no image is attached to the current turn.
- The summary source is the author-provided caption when present, otherwise the figure id; no second AI image-summary call is added.
- Preserve the existing attached-image flow for explicit figure attachments.
- Add a unit test that checks figure metadata is present in the prompt.