### PR TITLE
Add a single problem word extractor

### DIFF
--- a/src/exam_helper/app.py
+++ b/src/exam_helper/app.py
@@ -18,6 +18,7 @@ from pydantic import BaseModel, Field
 from exam_helper.ai_service import AIService
 from exam_helper.export_docx import (
     _PANDOC_MISSING_WARNING,
+    render_question_docx_bytes,
     render_project_docx_bytes,
 )
 from exam_helper.models import (
@@ -1217,6 +1218,37 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
         )
         project = repo.load_project()
         filename = f"{_sanitize_docx_filename_stem(project.name)}.docx"
+        headers = {
+            "Content-Disposition": f'attachment; filename="{filename}"',
+        }
+        if warnings:
+            headers["X-Exam-Helper-Export-Warnings"] = " | ".join(warnings)
+        response = Response(
+            content=content,
+            media_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            headers=headers,
+        )
+        if warnings:
+            response.set_cookie(
+                "exam_helper_export_warning",
+                " | ".join(warnings),
+                max_age=300,
+                samesite="lax",
+            )
+        return response
+
+    @app.post("/questions/{question_id}/export/docx")
+    def export_question_docx(
+        question_id: str, include_solutions: str | None = Form(None)
+    ) -> Response:
+        include = include_solutions is not None
+        content, warnings = render_question_docx_bytes(
+            project_root=project_root,
+            question_id=question_id,
+            include_solutions=include,
+        )
+        question = repo.get_question(question_id)
+        filename = f"{_sanitize_docx_filename_stem(question.id)}.docx"
         headers = {
             "Content-Disposition": f'attachment; filename="{filename}"',
         }

--- a/src/exam_helper/export_docx.py
+++ b/src/exam_helper/export_docx.py
@@ -341,11 +341,38 @@ def render_project_docx_bytes(
     project = repo.load_project()
     questions = repo.list_questions()
 
+    return _render_docx_bytes(
+        project_name=project.name,
+        course=project.course,
+        questions=questions,
+        include_solutions=include_solutions,
+    )
+
+
+def render_question_docx_bytes(
+    project_root: Path, question_id: str, include_solutions: bool = False
+) -> tuple[bytes, list[str]]:
+    repo = ProjectRepository(project_root)
+    project = repo.load_project()
+    question = repo.get_question(question_id)
+
+    return _render_docx_bytes(
+        project_name=project.name,
+        course=project.course,
+        questions=[question],
+        include_solutions=include_solutions,
+    )
+
+
+def _render_docx_bytes(
+    project_name: str, course: str, questions: list[Question], include_solutions: bool
+) -> tuple[bytes, list[str]]:
     warnings: list[str] = []
+
     try:
         return _render_docx_with_pandoc(
-            project_name=project.name,
-            course=project.course,
+            project_name=project_name,
+            course=course,
             questions=questions,
             include_solutions=include_solutions,
         )
@@ -355,8 +382,8 @@ def render_project_docx_bytes(
         warnings.append(_PANDOC_FAILED_WARNING)
 
     bytes_out = _render_docx_with_python_docx(
-        project_name=project.name,
-        course=project.course,
+        project_name=project_name,
+        course=course,
         questions=questions,
         include_solutions=include_solutions,
     )

--- a/src/exam_helper/templates/question_form_v2.html
+++ b/src/exam_helper/templates/question_form_v2.html
@@ -511,10 +511,16 @@
         <div class="actions">
           <button type="submit" class="btn">Save and Return</button>
           {% if question %}
-          <form class="export-form" method="post" action="/questions/{{ question.id }}/export/docx">
-            <button class="btn btn-secondary" type="submit">Export this question to DOCX</button>
-            <label><input type="checkbox" name="include_solutions" value="1" /> Include solutions</label>
-          </form>
+          <div class="export-form">
+            <button
+              class="btn btn-secondary"
+              type="submit"
+              formaction="/questions/{{ question.id }}/export/docx"
+              formmethod="post"
+              formnovalidate
+            >Export this question to DOCX</button>
+            <label><input type="checkbox" name="include_solutions" value="1" form="question-form" /> Include solutions</label>
+          </div>
           {% endif %}
           <span id="save_status" class="status">Ready</span>
         </div>

--- a/src/exam_helper/templates/question_form_v2.html
+++ b/src/exam_helper/templates/question_form_v2.html
@@ -518,6 +518,25 @@
               formaction="/questions/{{ question.id }}/export/docx"
               formmethod="post"
               formnovalidate
+              onclick="
+                if (this.dataset.autosaveSubmitting === '1') {
+                  this.dataset.autosaveSubmitting = '';
+                  return true;
+                }
+                var button = this;
+                var form = button.form;
+                if (!form || typeof autosaveNow !== 'function') {
+                  return true;
+                }
+                event.preventDefault();
+                button.dataset.autosaveSubmitting = '1';
+                Promise.resolve(autosaveNow())
+                  .catch(function () {})
+                  .finally(function () {
+                    form.requestSubmit(button);
+                  });
+                return false;
+              "
             >Export this question to DOCX</button>
             <label><input type="checkbox" name="include_solutions" value="1" form="question-form" /> Include solutions</label>
           </div>

--- a/src/exam_helper/templates/question_form_v2.html
+++ b/src/exam_helper/templates/question_form_v2.html
@@ -163,6 +163,12 @@
         gap: 1rem;
         flex-wrap: wrap;
       }
+      .export-form {
+        display: flex;
+        flex-direction: column;
+        gap: 0.35rem;
+        align-items: flex-start;
+      }
       .figure-item {
         border: 1px solid var(--line);
         border-radius: 14px;
@@ -504,6 +510,12 @@
 
         <div class="actions">
           <button type="submit" class="btn">Save and Return</button>
+          {% if question %}
+          <form class="export-form" method="post" action="/questions/{{ question.id }}/export/docx">
+            <button class="btn btn-secondary" type="submit">Export this question to DOCX</button>
+            <label><input type="checkbox" name="include_solutions" value="1" /> Include solutions</label>
+          </form>
+          {% endif %}
           <span id="save_status" class="status">Ready</span>
         </div>
       </form>

--- a/tests/integration/test_app_export_docx.py
+++ b/tests/integration/test_app_export_docx.py
@@ -66,3 +66,64 @@ def test_export_docx_route_include_solutions_and_warning_headers(tmp_path) -> No
     assert response.headers["content-disposition"] == 'attachment; filename="exam.docx"'
     assert "x-exam-helper-export-warnings" in response.headers
     assert "set-cookie" in response.headers
+
+
+def test_export_single_question_docx_route_uses_question_id_filename(tmp_path) -> None:
+    repo = ProjectRepository(tmp_path)
+    repo.init_project("Exam", "Physics")
+    app = create_app(tmp_path, openai_key=None)
+    client = TestClient(app)
+
+    save_resp = client.post(
+        "/questions/save",
+        data={
+            "question_id": "single-1",
+            "title": "Only One",
+            "question_type": "free_response",
+            "question_template_md": "A prompt.",
+            "solution_parameters_yaml": "{}",
+            "answer_formula_md": "",
+            "answer_guidance": "",
+            "mc_options_guidance": "",
+            "distractor_functions_text": "",
+            "choices_yaml": "[]",
+            "typed_solution_md": "",
+            "typed_solution_status": "fresh",
+            "figures_json": "[]",
+            "points": 5,
+        },
+        follow_redirects=False,
+    )
+    assert save_resp.status_code == 303
+
+    fake_docx = b"PK\x03\x04fake-docx"
+    captured = {"project_root": None, "question_id": None, "include": None}
+
+    def _fake_export(project_root, question_id, include_solutions=False):
+        captured["project_root"] = project_root
+        captured["question_id"] = question_id
+        captured["include"] = include_solutions
+        return fake_docx, ["single question warning"]
+
+    import exam_helper.app as app_module
+
+    original = app_module.render_question_docx_bytes
+    app_module.render_question_docx_bytes = _fake_export
+    try:
+        response = client.post(
+            "/questions/single-1/export/docx", data={"include_solutions": "1"}
+        )
+    finally:
+        app_module.render_question_docx_bytes = original
+
+    assert response.status_code == 200
+    assert captured["project_root"] == tmp_path
+    assert captured["question_id"] == "single-1"
+    assert captured["include"] is True
+    assert response.content == fake_docx
+    assert (
+        response.headers["content-disposition"]
+        == 'attachment; filename="single-1.docx"'
+    )
+    assert "x-exam-helper-export-warnings" in response.headers
+    assert "set-cookie" in response.headers

--- a/tests/integration/test_app_question_save.py
+++ b/tests/integration/test_app_question_save.py
@@ -194,7 +194,7 @@ def test_edit_existing_question_save_preserves_legacy_fields(tmp_path) -> None:
     assert 'id="mc_preview_answers"' in edit_html
     assert 'id="mc_preview_rationale"' in edit_html
     assert "Export this question to DOCX" in edit_html
-    assert "/questions/legacy-editor/export/docx" in edit_html
+    assert 'formaction="/questions/legacy-editor/export/docx"' in edit_html
     assert 'name="include_solutions"' in edit_html
 
     save_resp = client.post(

--- a/tests/integration/test_app_question_save.py
+++ b/tests/integration/test_app_question_save.py
@@ -193,6 +193,9 @@ def test_edit_existing_question_save_preserves_legacy_fields(tmp_path) -> None:
     assert 'id="rendered_answer_md"' in edit_html
     assert 'id="mc_preview_answers"' in edit_html
     assert 'id="mc_preview_rationale"' in edit_html
+    assert "Export this question to DOCX" in edit_html
+    assert "/questions/legacy-editor/export/docx" in edit_html
+    assert 'name="include_solutions"' in edit_html
 
     save_resp = client.post(
         "/questions/save",


### PR DESCRIPTION
fix #41

Change summary:
- Add a question-level DOCX export action directly from the question editor.
- Reuse the existing export pipeline, but export only the current question instead of the full project.
- Submit the export action with a dedicated `formaction` button so the browser stays on the question page.
- Name the downloaded file after the question id.
- Add integration coverage for the new route and editor control.