### PR TITLE
Handle jpg figure uploads and invalid file warnings

### DIFF
--- a/src/exam_helper/export_docx.py
+++ b/src/exam_helper/export_docx.py
@@ -22,6 +22,17 @@ _PANDOC_MISSING_WARNING = (
 _PANDOC_FAILED_WARNING = (
     "Pandoc conversion failed; DOCX was exported with plain-text math fallback."
 )
+_FIGURE_MIME_TYPES = {
+    "image/png": "png",
+    "image/jpeg": "jpg",
+    "image/gif": "gif",
+    "image/webp": "webp",
+    "image/svg+xml": "svg",
+}
+
+
+def _figure_file_extension(mime_type: str) -> str:
+    return _FIGURE_MIME_TYPES.get((mime_type or "").strip().lower(), "bin")
 
 
 def _render_prompt(question: Question) -> str:
@@ -164,11 +175,7 @@ def _build_project_markdown(
         for figure in q.figures:
             try:
                 raw = base64.b64decode(figure.data_base64.encode("ascii"))
-                ext = (
-                    figure.mime_type.split("/")[-1]
-                    if "/" in figure.mime_type
-                    else "bin"
-                )
+                ext = _figure_file_extension(figure.mime_type)
                 img_name = f"{q.id}_{figure.id}.{ext}"
                 img_path = image_dir / img_name
                 img_path.write_bytes(raw)

--- a/src/exam_helper/templates/question_form_v2.html
+++ b/src/exam_helper/templates/question_form_v2.html
@@ -841,38 +841,47 @@
         return figureId ? figureUrl(figureId) : "#";
       }
 
-      function isSupportedFigureFile(file) {
+      const SUPPORTED_FIGURE_FILE_TYPES = [
+        { extension: "png", mime_type: "image/png" },
+        { extension: "jpg", mime_type: "image/jpeg" },
+        { extension: "jpeg", mime_type: "image/jpeg" },
+        { extension: "gif", mime_type: "image/gif" },
+        { extension: "webp", mime_type: "image/webp" },
+        { extension: "svg", mime_type: "image/svg+xml" },
+      ];
+      const SUPPORTED_FIGURE_MIME_TYPES = new Set(
+        SUPPORTED_FIGURE_FILE_TYPES.map((item) => item.mime_type)
+      );
+
+      function fileExtensionFromName(name) {
+        const lower = String(name || "").trim().toLowerCase();
+        const match = lower.match(/\.([a-z0-9]+)$/);
+        return match ? match[1] : "";
+      }
+
+      function figureFileTypeFromFile(file) {
         const mimeType = String(file?.type || "").trim().toLowerCase();
-        if (mimeType.startsWith("image/")) {
-          return true;
+        if (mimeType) {
+          return SUPPORTED_FIGURE_MIME_TYPES.has(mimeType)
+            ? SUPPORTED_FIGURE_FILE_TYPES.find((item) => item.mime_type === mimeType)
+            : null;
         }
-        const name = String(file?.name || "").trim().toLowerCase();
-        return /\.(png|jpe?g|gif|webp|svg)$/i.test(name);
+        const ext = fileExtensionFromName(file?.name || "");
+        return (
+          SUPPORTED_FIGURE_FILE_TYPES.find((item) => item.extension === ext) || null
+        );
+      }
+
+      function isSupportedFigureFile(file) {
+        return figureFileTypeFromFile(file) !== null;
       }
 
       function figureMimeTypeFromFile(file) {
-        const mimeType = String(file?.type || "").trim().toLowerCase();
-        if (mimeType.startsWith("image/")) {
-          return mimeType;
-        }
-        const name = String(file?.name || "").trim().toLowerCase();
-        if (name.endsWith(".jpg") || name.endsWith(".jpeg")) {
-          return "image/jpeg";
-        }
-        if (name.endsWith(".svg")) {
-          return "image/svg+xml";
-        }
-        if (name.endsWith(".gif")) {
-          return "image/gif";
-        }
-        if (name.endsWith(".webp")) {
-          return "image/webp";
-        }
-        return "image/png";
+        return figureFileTypeFromFile(file)?.mime_type || "image/png";
       }
 
       function allowedFigureFileList() {
-        return ".png, .jpg, .jpeg, .gif, .webp, .svg";
+        return SUPPORTED_FIGURE_FILE_TYPES.map((item) => `.${item.extension}`).join(", ");
       }
 
       function clearFigureNotice() {

--- a/src/exam_helper/templates/question_form_v2.html
+++ b/src/exam_helper/templates/question_form_v2.html
@@ -201,6 +201,26 @@
         text-align: left;
         cursor: zoom-in;
       }
+      #figures_section {
+        position: relative;
+      }
+      .figure-notice {
+        display: none;
+        position: absolute;
+        top: 4rem;
+        right: 1rem;
+        max-width: min(30rem, calc(100% - 2rem));
+        padding: 0.75rem 0.9rem;
+        border-radius: 14px;
+        border: 1px solid #f0c87b;
+        background: #fff5df;
+        color: #8a4b1a;
+        box-shadow: 0 12px 24px rgba(90, 64, 28, 0.12);
+        z-index: 1;
+      }
+      .figure-notice.is-visible {
+        display: block;
+      }
       .figure-preview-button img {
         cursor: zoom-in;
       }
@@ -566,7 +586,8 @@
           <label>Figures (embedded)</label>
           <p class="hint">Paste into Question Template, drag/drop onto the page, or add image files here. The image data stays in the question YAML.</p>
           <button type="button" class="btn btn-secondary" id="btn_add_figure">Add Image File</button>
-          <input type="file" id="figure_file_input" accept="image/*" multiple style="display:none;" />
+          <input type="file" id="figure_file_input" accept="image/*,.svg" multiple style="display:none;" />
+          <div id="figure_notice" class="figure-notice" role="status" aria-live="polite"></div>
           <input type="hidden" id="figures_json" name="figures_json" value='{{ figures_json }}' />
           <div id="figures_preview">
             {% if question and question.figures %}
@@ -665,6 +686,7 @@
       const figureModalCloseEl = document.getElementById("figure_modal_close");
       const addFigureBtn = document.getElementById("btn_add_figure");
       const figureFileInput = document.getElementById("figure_file_input");
+      const figureNoticeEl = document.getElementById("figure_notice");
       const promptPreview = document.getElementById("prompt_preview");
       const mcBlock = document.getElementById("mc_block");
       const mcPreviewAnswers = document.getElementById("mc_preview_answers");
@@ -682,6 +704,7 @@
       let autosaveTimer = null;
       let pendingChatFigureIds = [];
       let figureModalLastFocus = null;
+      let figureNoticeTimer = null;
 
       function setStatus(text, cls) {
         saveStatus.textContent = text;
@@ -818,6 +841,75 @@
         return figureId ? figureUrl(figureId) : "#";
       }
 
+      function isSupportedFigureFile(file) {
+        const mimeType = String(file?.type || "").trim().toLowerCase();
+        if (mimeType.startsWith("image/")) {
+          return true;
+        }
+        const name = String(file?.name || "").trim().toLowerCase();
+        return /\.(png|jpe?g|gif|webp|svg)$/i.test(name);
+      }
+
+      function figureMimeTypeFromFile(file) {
+        const mimeType = String(file?.type || "").trim().toLowerCase();
+        if (mimeType.startsWith("image/")) {
+          return mimeType;
+        }
+        const name = String(file?.name || "").trim().toLowerCase();
+        if (name.endsWith(".jpg") || name.endsWith(".jpeg")) {
+          return "image/jpeg";
+        }
+        if (name.endsWith(".svg")) {
+          return "image/svg+xml";
+        }
+        if (name.endsWith(".gif")) {
+          return "image/gif";
+        }
+        if (name.endsWith(".webp")) {
+          return "image/webp";
+        }
+        return "image/png";
+      }
+
+      function allowedFigureFileList() {
+        return ".png, .jpg, .jpeg, .gif, .webp, .svg";
+      }
+
+      function clearFigureNotice() {
+        if (figureNoticeTimer) {
+          window.clearTimeout(figureNoticeTimer);
+          figureNoticeTimer = null;
+        }
+        if (!figureNoticeEl) {
+          return;
+        }
+        figureNoticeEl.classList.remove("is-visible");
+        figureNoticeEl.textContent = "";
+      }
+
+      function showFigureNotice(message) {
+        if (!figureNoticeEl) {
+          return;
+        }
+        clearFigureNotice();
+        figureNoticeEl.textContent = message;
+        figureNoticeEl.classList.add("is-visible");
+        figureNoticeTimer = window.setTimeout(() => {
+          clearFigureNotice();
+        }, 6000);
+      }
+
+      function summarizeRejectedFigureFiles(files) {
+        const names = files
+          .map((file) => String(file?.name || "unnamed file").trim())
+          .filter(Boolean)
+          .slice(0, 5);
+        const prefix = names.length
+          ? `Ignored ${names.join(", ")}.`
+          : "Ignored unsupported file.";
+        return `${prefix} Allowed figure files: ${allowedFigureFileList()}.`;
+      }
+
       function renderFiguresPreview() {
         const figures = parseFigures();
         if (!figures.length) {
@@ -913,7 +1005,7 @@
       }
 
       async function buildFigureFromFile(file) {
-        const mime = String(file.type || "").startsWith("image/") ? file.type : "image/png";
+        const mime = figureMimeTypeFromFile(file);
         const buf = await file.arrayBuffer();
         const dataBase64 = arrayBufferToBase64(buf);
         const validated = await validateFigureData(dataBase64);
@@ -926,7 +1018,7 @@
       }
 
       async function addFigureFromFile(file, fallbackAppend = true) {
-        if (!file || !String(file.type || "").startsWith("image/")) return false;
+        if (!file || !isSupportedFigureFile(file)) return false;
         const figures = parseFigures();
         const pendingId = nextFigureId(figures);
         setStatus("Processing image...", "warn");
@@ -942,7 +1034,7 @@
       }
 
       async function addChatAttachmentFromFile(file) {
-        if (!file || !String(file.type || "").startsWith("image/")) return false;
+        if (!file || !isSupportedFigureFile(file)) return false;
         const figures = parseFigures();
         const pendingId = nextFigureId(figures);
         setChatStatus("Processing chat image...", "warn");
@@ -967,6 +1059,47 @@
           }
         }
         return files;
+      }
+
+      function splitSupportedFigureFiles(files) {
+        const valid = [];
+        const rejected = [];
+        for (const file of files || []) {
+          if (isSupportedFigureFile(file)) {
+            valid.push(file);
+          } else {
+            rejected.push(file);
+          }
+        }
+        return { valid, rejected };
+      }
+
+      async function addFigureFiles(files, fallbackAppend = true) {
+        const { valid, rejected } = splitSupportedFigureFiles(files);
+        if (rejected.length) {
+          showFigureNotice(summarizeRejectedFigureFiles(rejected));
+        }
+        if (!valid.length) {
+          return false;
+        }
+        for (const file of valid) {
+          await addFigureFromFile(file, fallbackAppend);
+        }
+        return true;
+      }
+
+      async function addChatFigureFiles(files) {
+        const { valid, rejected } = splitSupportedFigureFiles(files);
+        if (rejected.length) {
+          setChatStatus(summarizeRejectedFigureFiles(rejected), "warn");
+        }
+        if (!valid.length) {
+          return false;
+        }
+        for (const file of valid) {
+          await addChatAttachmentFromFile(file);
+        }
+        return true;
       }
 
       function renderTemplate() {
@@ -1300,9 +1433,7 @@
         const files = Array.from(figureFileInput.files || []);
         if (!files.length) return;
         try {
-          for (const file of files) {
-            await addFigureFromFile(file, true);
-          }
+          await addFigureFiles(files, true);
         } catch (err) {
           setStatus(`Image error: ${err.message}`, "warn");
         } finally {
@@ -1333,9 +1464,7 @@
         if (!files.length) return;
         event.preventDefault();
         try {
-          for (const file of files) {
-            await addFigureFromFile(file, false);
-          }
+          await addFigureFiles(files, false);
         } catch (err) {
           setStatus(`Image paste error: ${err.message}`, "warn");
         }
@@ -1346,17 +1475,17 @@
         if (!files.length) return;
         event.preventDefault();
         try {
-          for (const file of files) {
-            await addChatAttachmentFromFile(file);
-          }
+          await addChatFigureFiles(files);
         } catch (err) {
           setChatStatus(`Chat image error: ${err.message}`, "warn");
         }
       });
 
       document.addEventListener("dragover", (event) => {
-        const hasImage = Array.from(event.dataTransfer?.items || []).some((item) => item.kind === "file" && String(item.type || "").startsWith("image/"));
-        if (hasImage) {
+        const hasFileItem = Array.from(event.dataTransfer?.items || []).some(
+          (item) => item.kind === "file"
+        );
+        if (hasFileItem) {
           event.preventDefault();
           figuresSectionEl.style.borderColor = "#0f766e";
         }
@@ -1368,21 +1497,18 @@
 
       document.addEventListener("drop", async (event) => {
         figuresSectionEl.style.borderColor = "";
-        const files = Array.from(event.dataTransfer?.files || []).filter((f) => String(f.type || "").startsWith("image/"));
+        clearFigureNotice();
+        const files = Array.from(event.dataTransfer?.files || []);
         if (!files.length) return;
         event.preventDefault();
         try {
           const dropTarget = event.target instanceof Element ? event.target.closest(".chat-panel") : null;
           if (dropTarget) {
-            for (const file of files) {
-              await addChatAttachmentFromFile(file);
-            }
+            await addChatFigureFiles(files);
             return;
           }
           const appendFallback = document.activeElement !== templateEl;
-          for (const file of files) {
-            await addFigureFromFile(file, appendFallback);
-          }
+          await addFigureFiles(files, appendFallback);
         } catch (err) {
           setStatus(`Image drop error: ${err.message}`, "warn");
         }

--- a/tests/integration/test_app_question_save.py
+++ b/tests/integration/test_app_question_save.py
@@ -117,6 +117,8 @@ def test_new_question_page_contains_figure_upload_controls(tmp_path) -> None:
     assert 'id="figures_preview"' in html
     assert 'id="btn_add_figure"' in html
     assert 'id="figure_file_input"' in html
+    assert 'id="figure_notice"' in html
+    assert 'accept="image/*,.svg"' in html
 
     redirect = client.get("/questions/new", follow_redirects=False)
     assert redirect.status_code == 303

--- a/tests/integration/test_browser_question_roundtrip.py
+++ b/tests/integration/test_browser_question_roundtrip.py
@@ -418,3 +418,124 @@ def test_browser_figure_preview_modal_opens_and_closes(tmp_path: Path) -> None:
         except subprocess.TimeoutExpired:
             proc.kill()
             proc.wait(timeout=10)
+
+
+def test_browser_figure_drop_accepts_jpg_svg_and_warns_on_bad_files(
+    tmp_path: Path,
+) -> None:
+    pytest.importorskip("playwright.sync_api")
+    from playwright.sync_api import Error as PlaywrightError, sync_playwright
+
+    repo = ProjectRepository(tmp_path)
+    repo.init_project("Figure Upload Exam", "Physics 1")
+    port = _free_port()
+    base_url = f"http://127.0.0.1:{port}"
+
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "exam_helper.cli",
+            "serve",
+            str(tmp_path),
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    try:
+        _wait_for_server(base_url + "/", proc)
+        seed = httpx.post(
+            base_url + "/questions/save",
+            data={
+                "question_id": "q_upload",
+                "title": "Figure Upload Test",
+                "question_type": "free_response",
+                "question_template_md": "Upload a figure.",
+                "solution_parameters_yaml": "{}",
+                "answer_formula_md": "answer = 1",
+                "answer_guidance": "",
+                "mc_options_guidance": "",
+                "distractor_functions_text": "",
+                "choices_yaml": "[]",
+                "typed_solution_md": "",
+                "typed_solution_status": "fresh",
+                "figures_json": "[]",
+                "points": 5,
+            },
+            follow_redirects=False,
+            timeout=5.0,
+        )
+        assert seed.status_code == 303
+        with sync_playwright() as p:
+            try:
+                browser = p.chromium.launch(headless=True)
+            except PlaywrightError as exc:
+                pytest.skip(f"Chromium is not available: {exc}")
+            try:
+                page = browser.new_page()
+                page.goto(base_url + "/questions/q_upload/edit")
+                page.wait_for_url(base_url + "/questions/q_upload/edit")
+
+                page.evaluate("""() => {
+                        const section = document.querySelector("#figures_section");
+                        const transfer = new DataTransfer();
+                        transfer.items.add(new File(
+                          [new Uint8Array([1, 2, 3, 4])],
+                          "photo.jpg",
+                          { type: "" }
+                        ));
+                        transfer.items.add(new File(
+                          [new Uint8Array([5, 6, 7, 8])],
+                          "diagram.svg",
+                          { type: "" }
+                        ));
+                        transfer.items.add(new File(
+                          [new TextEncoder().encode("not an image")],
+                          "notes.txt",
+                          { type: "text/plain" }
+                        ));
+                        section.dispatchEvent(new DragEvent("dragover", {
+                          bubbles: true,
+                          cancelable: true,
+                          dataTransfer: transfer
+                        }));
+                        section.dispatchEvent(new DragEvent("drop", {
+                          bubbles: true,
+                          cancelable: true,
+                          dataTransfer: transfer
+                        }));
+                    }""")
+
+                page.wait_for_function(
+                    "() => document.querySelectorAll('#figures_preview .figure-item').length === 2"
+                )
+
+                notice = page.locator("#figure_notice")
+                assert notice.is_visible()
+                assert "notes.txt" in notice.inner_text()
+                assert ".jpg" in notice.inner_text()
+
+                first_src = page.locator(
+                    "#figures_preview .figure-item:nth-of-type(1) img"
+                ).get_attribute("src")
+                second_src = page.locator(
+                    "#figures_preview .figure-item:nth-of-type(2) img"
+                ).get_attribute("src")
+                assert first_src is not None
+                assert second_src is not None
+                assert first_src.startswith("data:image/jpeg;base64,")
+                assert second_src.startswith("data:image/svg+xml;base64,")
+            finally:
+                browser.close()
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=10)

--- a/tests/integration/test_export_docx.py
+++ b/tests/integration/test_export_docx.py
@@ -69,6 +69,47 @@ def test_export_docx_with_embedded_figure(tmp_path: Path) -> None:
     assert "<w:numPr>" in xml
 
 
+def test_export_docx_uses_svg_extension_for_svg_figures(
+    tmp_path: Path, monkeypatch
+) -> None:
+    repo = ProjectRepository(tmp_path)
+    repo.init_project("Exam", "Physics")
+
+    raw = b"<svg xmlns='http://www.w3.org/2000/svg'></svg>"
+    b64 = base64.b64encode(raw).decode("ascii")
+    raw_hash = hashlib.sha256(raw).hexdigest()
+    fig = FigureData(
+        id="fig_1",
+        mime_type="image/svg+xml",
+        data_base64=b64,
+        sha256=raw_hash,
+        caption="svg figure",
+    )
+    q = Question(
+        id="q1",
+        title="t",
+        points=5,
+        figures=[fig],
+        solution={"question_template_md": "p"},
+    )
+    repo.save_question(q)
+
+    def _fake_pandoc(cmd, check, capture_output, text, cwd):
+        md_path = Path(cmd[1])
+        markdown = md_path.read_text(encoding="utf-8")
+        assert "q1_fig_1.svg" in markdown
+        out_path = Path(cmd[cmd.index("-o") + 1])
+        d = Document()
+        d.add_paragraph("[5 points] p")
+        d.save(out_path)
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr("exam_helper.export_docx.subprocess.run", _fake_pandoc)
+    content, warnings = render_project_docx_bytes(tmp_path)
+    assert warnings == []
+    assert content
+
+
 def test_export_docx_includes_solution_when_enabled(tmp_path: Path) -> None:
     repo = ProjectRepository(tmp_path)
     repo.init_project("Exam", "Physics")


### PR DESCRIPTION
Fixes #108

- Accept figure uploads by extension as well as MIME type so .jpg and .svg drops work when the browser does not populate `file.type`.
- Show an in-page notice when unsupported files are dropped or selected, including the allowed figure file types.
- Add regression coverage for the rendered upload controls and the drop behavior.

Validation:
- `uv run --extra dev pytest -q tests/integration/test_app_question_save.py -k figure`
- `uv run --extra dev pytest -q tests/integration/test_browser_question_roundtrip.py -k "figure_drop_accepts_jpg_svg_and_warns_on_bad_files or figure_preview_modal_opens_and_closes"`
- `uv run --extra dev black --check tests/integration/test_browser_question_roundtrip.py tests/integration/test_app_question_save.py`

Remaining risk:
- The browser-specific drop regression is skipped locally because Playwright is not installed in this environment; CI should exercise it.