### PR TITLE
Indent MC preview explanations with lists

### DIFF
--- a/src/exam_helper/templates/question_form_v2.html
+++ b/src/exam_helper/templates/question_form_v2.html
@@ -128,6 +128,16 @@
       .mc-preview-text {
         white-space: pre-wrap;
       }
+      .mc-preview-list {
+        margin: 0;
+        padding-left: 1.5rem;
+        display: grid;
+        gap: 0.35rem;
+        white-space: normal;
+      }
+      .mc-preview-list li {
+        margin: 0;
+      }
       .formula-preview--compact {
         min-height: 0;
         display: inline-block;
@@ -1088,7 +1098,7 @@
               stripDisallowedBold(String(choice.content_md || ""))
             )
           );
-          return `<div><strong>${label}.</strong> <span>${content}</span></div>`;
+          return `<li><strong>${label}.</strong> <span>${content}</span></li>`;
         }).join("");
         const previewRationaleHtml = choices.map((choice) => {
           const label = escapeHtml(String(choice.label || "?"));
@@ -1101,10 +1111,10 @@
           const rationale = rationaleText
             ? ` - ${marked.parseInline(normalizeMathDelimitersForPreview(rationaleText))}`
             : "";
-          return `<div><strong>${label}.</strong> <span>${content}${rationale}</span></div>`;
+          return `<li><strong>${label}.</strong> <span>${content}${rationale}</span></li>`;
         }).join("");
-        mcPreviewAnswers.innerHTML = previewAnswersHtml;
-        mcPreviewRationale.innerHTML = previewRationaleHtml;
+        mcPreviewAnswers.innerHTML = `<ol class="mc-preview-list">${previewAnswersHtml}</ol>`;
+        mcPreviewRationale.innerHTML = `<ol class="mc-preview-list">${previewRationaleHtml}</ol>`;
         if (window.MathJax && window.MathJax.typesetPromise) {
           window.MathJax.typesetPromise([mcPreviewAnswers, mcPreviewRationale]);
           rows.forEach((_, idx) => {

--- a/tests/integration/test_browser_question_roundtrip.py
+++ b/tests/integration/test_browser_question_roundtrip.py
@@ -287,6 +287,9 @@ def test_browser_chat_response_updates_visible_mc_rows(tmp_path: Path) -> None:
                     "(el) => el.getBoundingClientRect().height"
                 )
                 assert preview_height < 40
+                assert page.locator("#mc_preview_answers ol").count() == 1
+                assert page.locator("#mc_preview_rationale ol").count() == 1
+                assert page.locator("#mc_preview_rationale li").count() == 4
             finally:
                 browser.close()
     finally:


### PR DESCRIPTION
Fixes #95

- Render the multiple-choice preview answers and explanations as ordered lists so wrapped lines hang under the list marker.
- Keep the preview styling consistent with the rest of the editor and preserve the existing answer preview behavior.
- Add regression coverage that checks for list markup in the preview render path.

Validation:
- `uv run --extra dev pytest -q tests/integration/test_browser_question_roundtrip.py -k "browser_chat_response_updates_visible_mc_rows or figure_preview_modal_opens_and_closes"`
- `uv run --extra dev black --check tests/integration/test_browser_question_roundtrip.py`

Remaining risk:
- The browser-specific preview regression is skipped locally because Playwright is not installed in this environment; CI should exercise it.