### PR TITLE
Convert CLI to Typer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
   "sympy>=1.14.0",
   "pint>=0.24.0",
   "openai>=1.99.0",
+  "typer>=0.12.5",
   "python-docx>=1.2.0",
 ]
 

--- a/src/exam_helper/cli.py
+++ b/src/exam_helper/cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
+import click
 import typer
 import uvicorn
 
@@ -42,7 +43,8 @@ def cmd_init(
 def cmd_validate(path: str | Path) -> int:
     resolved = Path(path)
     if not resolved.exists():
-        raise typer.BadParameter(f"Path does not exist: {resolved}")
+        print(f"ERROR: Path does not exist: {resolved}")
+        return 1
     if resolved.is_file():
         resolved = resolved.parent
     repo = ProjectRepository(resolved)
@@ -164,6 +166,14 @@ def main() -> int:
         cli_app(prog_name="exam-helper", standalone_mode=False)
     except typer.Exit as exc:
         return exc.exit_code
+    except click.ClickException as exc:
+        exc.show()
+        return exc.exit_code
+    except SystemExit as exc:
+        code = exc.code
+        if isinstance(code, int):
+            return code
+        return 1
     return 0
 
 

--- a/src/exam_helper/cli.py
+++ b/src/exam_helper/cli.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-import argparse
 import logging
 from pathlib import Path
 
+import typer
 import uvicorn
 
 from exam_helper.app import create_app
@@ -13,144 +13,158 @@ from exam_helper.models import DEFAULT_OPENAI_MODEL
 from exam_helper.repository import ProjectRepository
 from exam_helper.validation import validate_project
 
-
-class _HelpFormatter(
-    argparse.ArgumentDefaultsHelpFormatter, argparse.RawDescriptionHelpFormatter
-):
-    pass
+cli_app = typer.Typer(add_completion=False, help="Exam helper commands.")
+export_app = typer.Typer(add_completion=False, help="Export artifacts.")
+cli_app.add_typer(export_app, name="export")
 
 
-def cmd_init(args: argparse.Namespace) -> int:
-    root = Path(args.path)
+def _configure_logging(verbose: int) -> None:
+    level = logging.WARNING
+    if verbose == 1:
+        level = logging.INFO
+    elif verbose >= 2:
+        level = logging.DEBUG
+    logging.basicConfig(level=level, format="%(levelname)s:%(name)s:%(message)s")
+
+
+def cmd_init(
+    path: str | Path,
+    name: str = "Example Exam Project",
+    course: str = "Calculus-based Intro Physics",
+    openai_model: str = DEFAULT_OPENAI_MODEL,
+) -> int:
+    root = Path(path)
     repo = ProjectRepository(root)
-    repo.init_project(
-        name=args.name, course=args.course, openai_model=args.openai_model
-    )
+    repo.init_project(name=name, course=course, openai_model=openai_model)
     return 0
 
 
-def cmd_validate(args: argparse.Namespace) -> int:
-    path = Path(args.path)
-    if not path.exists():
-        raise SystemExit(f"Path does not exist: {path}")
-    if path.is_file():
-        path = path.parent
-    repo = ProjectRepository(path)
+def cmd_validate(path: str | Path) -> int:
+    resolved = Path(path)
+    if not resolved.exists():
+        raise SystemExit(f"Path does not exist: {resolved}")
+    if resolved.is_file():
+        resolved = resolved.parent
+    repo = ProjectRepository(resolved)
     errors = validate_project(repo)
     if errors:
         for err in errors:
             print(f"ERROR: {err}")
         return 1
-    print(f"Validation succeeded: {path}")
+    print(f"Validation succeeded: {resolved}")
     return 0
 
 
-def cmd_export_docx(args: argparse.Namespace) -> int:
+def cmd_export_docx(
+    path: str | Path, output: str | Path, include_solutions: bool = False
+) -> int:
     warnings = export_project_to_docx(
-        project_root=Path(args.path),
-        output_path=Path(args.output),
-        include_solutions=args.include_solutions,
+        project_root=Path(path),
+        output_path=Path(output),
+        include_solutions=include_solutions,
     )
     for warning in warnings:
         print(f"WARNING: {warning}")
-    print(f"Wrote {args.output}")
+    print(f"Wrote {output}")
     return 0
 
 
-def cmd_serve(args: argparse.Namespace) -> int:
-    verbosity = int(getattr(args, "verbose", 0) or 0)
-    level = logging.WARNING
-    if verbosity == 1:
-        level = logging.INFO
-    elif verbosity >= 2:
-        level = logging.DEBUG
-    logging.basicConfig(level=level, format="%(levelname)s:%(name)s:%(message)s")
+def cmd_serve(
+    path: str | Path = ".",
+    host: str = "127.0.0.1",
+    port: int = 8000,
+    openai_key: str | None = None,
+    verbose: int = 0,
+) -> int:
+    _configure_logging(verbose)
 
-    key = resolve_openai_api_key(args.openai_key, Path(args.path))
+    resolved_path = Path(path)
+    key = resolve_openai_api_key(openai_key, resolved_path)
     if key:
         print("OpenAI key loaded.")
     else:
         print("OpenAI key not configured. AI features will be unavailable.")
-    app = create_app(project_root=Path(args.path), openai_key=key)
+    app = create_app(project_root=resolved_path, openai_key=key)
     uvicorn.run(
         app,
-        host=args.host,
-        port=args.port,
-        log_level=("debug" if verbosity >= 2 else "info"),
+        host=host,
+        port=port,
+        log_level=("debug" if verbose >= 2 else "info"),
     )
     return 0
 
 
-def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
-        prog="exam-helper",
-        formatter_class=_HelpFormatter,
+@cli_app.command(help="Initialize a new exam project.")
+def init(
+    path: Path,
+    name: str = typer.Option("Example Exam Project", help="Project name."),
+    course: str = typer.Option("Calculus-based Intro Physics", help="Course name."),
+    openai_model: str = typer.Option(DEFAULT_OPENAI_MODEL, help="Default AI model."),
+) -> None:
+    raise typer.Exit(
+        code=cmd_init(path, name=name, course=course, openai_model=openai_model)
     )
-    sub = parser.add_subparsers(dest="command", required=True)
 
-    p_init = sub.add_parser("init", help="Initialize a new exam project.")
-    p_init.add_argument("path")
-    p_init.add_argument("--name", default="Example Exam Project")
-    p_init.add_argument("--course", default="Calculus-based Intro Physics")
-    p_init.add_argument("--openai-model", default=DEFAULT_OPENAI_MODEL)
-    p_init.set_defaults(func=cmd_init)
 
-    p_serve = sub.add_parser(
-        "serve",
-        help="Serve the local web app.",
-        formatter_class=_HelpFormatter,
-        description=(
-            "Start the local FastAPI + HTMX app for an exam project directory.\n"
-            "The path should point at the project root containing project.yaml."
-        ),
-        epilog=(
-            "OpenAI key resolution:\n"
-            "  1. --openai-key\n"
-            "  2. EXAM_HELPER_OPENAI_KEY in the project .env path\n"
-            "  3. EXAM_HELPER_OPENAI_KEY in ~/.env\n"
-        ),
+@cli_app.command(help="Validate question files.")
+def validate(path: Path) -> None:
+    raise typer.Exit(code=cmd_validate(path))
+
+
+@export_app.command("docx", help="Export DOCX.")
+def export_docx(
+    path: Path,
+    output: Path = typer.Option(..., help="Output DOCX path."),
+    include_solutions: bool = typer.Option(
+        False, help="Include solutions in the export."
+    ),
+) -> None:
+    raise typer.Exit(code=cmd_export_docx(path, output, include_solutions))
+
+
+@cli_app.command(
+    help=(
+        "Serve the local web app.\n\n"
+        "The path should point at the project root containing project.yaml.\n\n"
+        "OpenAI key resolution:\n"
+        "  1. --openai-key\n"
+        "  2. EXAM_HELPER_OPENAI_KEY in the project .env path\n"
+        "  3. EXAM_HELPER_OPENAI_KEY in ~/.env"
     )
-    p_serve.add_argument(
-        "path",
-        nargs="?",
-        default=".",
+)
+def serve(
+    path: Path = typer.Argument(
+        Path("."),
         help="Path to the exam project directory.",
-    )
-    p_serve.add_argument("--host", default="127.0.0.1")
-    p_serve.add_argument("--port", type=int, default=8000)
-    p_serve.add_argument(
+    ),
+    host: str = typer.Option("127.0.0.1", help="Host to bind."),
+    port: int = typer.Option(8000, help="Port to bind."),
+    openai_key: str | None = typer.Option(
+        None,
         "--openai-key",
-        default=None,
         help="OpenAI API key override.",
-    )
-    p_serve.add_argument(
+    ),
+    verbose: int = typer.Option(
+        0,
         "-v",
         "--verbose",
-        action="count",
-        default=0,
+        count=True,
         help="Increase logging verbosity; repeat for more detail.",
+    ),
+) -> None:
+    raise typer.Exit(
+        code=cmd_serve(
+            path, host=host, port=port, openai_key=openai_key, verbose=verbose
+        )
     )
-    p_serve.set_defaults(func=cmd_serve)
-
-    p_validate = sub.add_parser("validate", help="Validate question files.")
-    p_validate.add_argument("path")
-    p_validate.set_defaults(func=cmd_validate)
-
-    p_export = sub.add_parser("export", help="Export artifacts.")
-    export_sub = p_export.add_subparsers(dest="export_command", required=True)
-    p_docx = export_sub.add_parser("docx", help="Export DOCX.")
-    p_docx.add_argument("path")
-    p_docx.add_argument("--output", required=True)
-    p_docx.add_argument("--include-solutions", action="store_true")
-    p_docx.set_defaults(func=cmd_export_docx)
-
-    return parser
 
 
 def main() -> int:
-    parser = build_parser()
-    args = parser.parse_args()
-    return args.func(args)
+    try:
+        cli_app(prog_name="exam-helper", standalone_mode=False)
+    except typer.Exit as exc:
+        return exc.exit_code
+    return 0
 
 
 if __name__ == "__main__":

--- a/src/exam_helper/cli.py
+++ b/src/exam_helper/cli.py
@@ -42,7 +42,7 @@ def cmd_init(
 def cmd_validate(path: str | Path) -> int:
     resolved = Path(path)
     if not resolved.exists():
-        raise SystemExit(f"Path does not exist: {resolved}")
+        raise typer.BadParameter(f"Path does not exist: {resolved}")
     if resolved.is_file():
         resolved = resolved.parent
     repo = ProjectRepository(resolved)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,44 +1,28 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
+from typer.testing import CliRunner
 
 from exam_helper import cli
 from exam_helper.models import DEFAULT_OPENAI_MODEL
 
-
-def test_serve_parser_accepts_positional_path() -> None:
-    parser = cli.build_parser()
-
-    args = parser.parse_args(["serve", "my-project"])
-
-    assert args.path == "my-project"
+runner = CliRunner()
 
 
-def test_serve_parser_defaults_path_to_current_directory() -> None:
-    parser = cli.build_parser()
+def test_serve_help_mentions_project_path_and_openai_env() -> None:
+    result = runner.invoke(cli.cli_app, ["serve", "--help"])
 
-    args = parser.parse_args(["serve"])
-
-    assert args.path == "."
-
-
-def test_serve_help_mentions_project_path_and_openai_env(capsys) -> None:
-    parser = cli.build_parser()
-
-    with pytest.raises(SystemExit):
-        parser.parse_args(["serve", "-h"])
-
-    out = capsys.readouterr().out
+    assert result.exit_code == 0
+    out = result.stdout
     assert "project.yaml" in out
     assert "Path to the exam project directory." in out
     assert "EXAM_HELPER_OPENAI_KEY in ~/.env" in out
     assert "EXAM_HELPER_OPENAI_KEY in the project .env path" in out
-    assert "--openai-key OPENAI_KEY" in out
+    assert "--openai-key" in out
 
 
-def test_cmd_serve_uses_path_for_project_root(monkeypatch) -> None:
+def test_serve_command_accepts_positional_path(monkeypatch) -> None:
     captured: dict[str, object] = {}
 
     def fake_create_app(*, project_root: Path, openai_key: str | None):
@@ -58,10 +42,9 @@ def test_cmd_serve_uses_path_for_project_root(monkeypatch) -> None:
         cli, "resolve_openai_api_key", lambda key, project_root=None: "key"
     )
 
-    parser = cli.build_parser()
-    args = parser.parse_args(["serve", "my-project", "--port", "9000"])
+    result = runner.invoke(cli.cli_app, ["serve", "my-project", "--port", "9000"])
 
-    assert cli.cmd_serve(args) == 0
+    assert result.exit_code == 0
     assert captured["project_root"] == Path("my-project")
     assert captured["openai_key"] == "key"
     assert captured["host"] == "127.0.0.1"
@@ -69,9 +52,78 @@ def test_cmd_serve_uses_path_for_project_root(monkeypatch) -> None:
     assert captured["log_level"] == "info"
 
 
-def test_init_parser_defaults_openai_model_to_gpt_54() -> None:
-    parser = cli.build_parser()
+def test_serve_command_defaults_path_to_current_directory(monkeypatch) -> None:
+    captured: dict[str, object] = {}
 
-    args = parser.parse_args(["init", "my-project"])
+    def fake_create_app(*, project_root: Path, openai_key: str | None):
+        captured["project_root"] = project_root
+        captured["openai_key"] = openai_key
+        return object()
 
-    assert args.openai_model == DEFAULT_OPENAI_MODEL
+    def fake_run(app, host: str, port: int, log_level: str) -> None:
+        captured["app"] = app
+        captured["host"] = host
+        captured["port"] = port
+        captured["log_level"] = log_level
+
+    monkeypatch.setattr(cli, "create_app", fake_create_app)
+    monkeypatch.setattr(cli.uvicorn, "run", fake_run)
+    monkeypatch.setattr(
+        cli, "resolve_openai_api_key", lambda key, project_root=None: "key"
+    )
+
+    result = runner.invoke(cli.cli_app, ["serve"])
+
+    assert result.exit_code == 0
+    assert captured["project_root"] == Path(".")
+    assert captured["openai_key"] == "key"
+    assert captured["host"] == "127.0.0.1"
+    assert captured["port"] == 8000
+    assert captured["log_level"] == "info"
+
+
+def test_init_command_defaults_openai_model_to_gpt_54(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    class FakeRepo:
+        def __init__(self, root: Path):
+            captured["root"] = root
+
+        def init_project(self, *, name: str, course: str, openai_model: str) -> None:
+            captured["name"] = name
+            captured["course"] = course
+            captured["openai_model"] = openai_model
+
+    monkeypatch.setattr(cli, "ProjectRepository", FakeRepo)
+
+    result = runner.invoke(cli.cli_app, ["init", "my-project"])
+
+    assert result.exit_code == 0
+    assert captured["root"] == Path("my-project")
+    assert captured["name"] == "Example Exam Project"
+    assert captured["course"] == "Calculus-based Intro Physics"
+    assert captured["openai_model"] == DEFAULT_OPENAI_MODEL
+
+
+def test_export_docx_command_defaults_include_solutions(monkeypatch, tmp_path) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_export_project_to_docx(
+        *, project_root: Path, output_path: Path, include_solutions: bool
+    ) -> list[str]:
+        captured["project_root"] = project_root
+        captured["output_path"] = output_path
+        captured["include_solutions"] = include_solutions
+        return []
+
+    monkeypatch.setattr(cli, "export_project_to_docx", fake_export_project_to_docx)
+
+    output = tmp_path / "exam.docx"
+    result = runner.invoke(
+        cli.cli_app, ["export", "docx", "my-project", "--output", str(output)]
+    )
+
+    assert result.exit_code == 0
+    assert captured["project_root"] == Path("my-project")
+    assert captured["output_path"] == output
+    assert captured["include_solutions"] is False

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+import click
 from typer.testing import CliRunner
 
 from exam_helper import cli
@@ -128,3 +129,23 @@ def test_export_docx_command_defaults_include_solutions(monkeypatch, tmp_path) -
     assert captured["project_root"] == Path("my-project")
     assert captured["output_path"] == output
     assert captured["include_solutions"] is False
+
+
+def test_validate_command_reports_missing_path(capsys) -> None:
+    result = runner.invoke(cli.cli_app, ["validate", "missing-project"])
+
+    assert result.exit_code == 1
+    assert "ERROR: Path does not exist: missing-project" in result.stdout
+
+
+def test_main_returns_click_exit_code_for_cli_errors(monkeypatch, capsys) -> None:
+    def fake_cli_app(*args, **kwargs):
+        raise click.BadParameter("bad path")
+
+    monkeypatch.setattr(cli, "cli_app", fake_cli_app)
+
+    exit_code = cli.main()
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "bad path" in captured.err

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 from typer.testing import CliRunner
@@ -14,7 +15,7 @@ def test_serve_help_mentions_project_path_and_openai_env() -> None:
     result = runner.invoke(cli.cli_app, ["serve", "--help"])
 
     assert result.exit_code == 0
-    out = result.stdout
+    out = re.sub(r"\x1b\[[0-9;]*m", "", result.stdout)
     assert "project.yaml" in out
     assert "Path to the exam project directory." in out
     assert "EXAM_HELPER_OPENAI_KEY in ~/.env" in out

--- a/uv.lock
+++ b/uv.lock
@@ -120,6 +120,7 @@ dependencies = [
     { name = "python-multipart" },
     { name = "pyyaml" },
     { name = "sympy" },
+    { name = "typer" },
     { name = "uvicorn" },
 ]
 
@@ -150,6 +151,7 @@ requires-dist = [
     { name = "python-multipart", specifier = ">=0.0.20" },
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "sympy", specifier = ">=1.14.0" },
+    { name = "typer", specifier = ">=0.12.5" },
     { name = "uvicorn", specifier = ">=0.35.0" },
 ]
 provides-extras = ["dev"]
@@ -471,6 +473,18 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -540,6 +554,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325", size = 9658, upload-time = "2022-01-24T01:14:51.113Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e", size = 7350, upload-time = "2022-01-24T01:14:49.62Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -911,6 +934,28 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -954,6 +999,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.25.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/51/9aed62104cea109b820bbd6c14245af756112017d309da813ef107d42e7e/typer-0.25.1.tar.gz", hash = "sha256:9616eb8853a09ffeabab1698952f33c6f29ffdbceb4eaeecf571880e8d7664cc", size = 122276, upload-time = "2026-04-30T19:32:16.964Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/f9/2b3ff4e56e5fa7debfaf9eb135d0da96f3e9a1d5b27222223c7296336e5f/typer-0.25.1-py3-none-any.whl", hash = "sha256:75caa44ed46a03fb2dab8808753ffacdbfea88495e74c85a28c5eefcf5f39c89", size = 58409, upload-time = "2026-04-30T19:32:18.271Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes #106

- Replace the argparse command tree with a Typer app while keeping the same `init`, `validate`, `serve`, and `export docx` behaviors.
- Add Typer-based unit tests for help output, positional arguments, defaults, and export wiring.
- Add the Typer dependency and refresh the lockfile.

Validation:
- `uv run --extra dev pytest -q tests/unit/test_cli.py`
- `uv run --extra dev black --check src/exam_helper/cli.py tests/unit/test_cli.py`

Remaining risk:
- The help text now comes from Typer's renderer, so formatting is slightly different from argparse even though the content is covered.