### PR TITLE
Summarize uploaded figures with AI

### DIFF
--- a/src/exam_helper/ai_service.py
+++ b/src/exam_helper/ai_service.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import base64
+import binascii
 import json
 import logging
 import re
@@ -39,6 +41,14 @@ class AIService:
     model: str = DEFAULT_OPENAI_MODEL
     prompts_override: AIPromptConfig | None = None
     prompt_catalog: PromptCatalog | None = None
+    _SUPPORTED_FIGURE_SUMMARY_MIME_TYPES = {
+        "image/png",
+        "image/jpeg",
+        "image/gif",
+        "image/webp",
+        "image/svg+xml",
+    }
+    _MAX_FIGURE_SUMMARY_BYTES = 2 * 1024 * 1024
 
     @dataclass
     class AIResult:
@@ -250,7 +260,35 @@ class AIService:
             f"- {item}" for item in summaries
         )
 
+    @classmethod
+    def _prepare_figure_summary_input(
+        cls, mime_type: str, data_base64: str
+    ) -> tuple[str, str]:
+        normalized_mime = str(mime_type or "").strip().lower() or "image/png"
+        if normalized_mime not in cls._SUPPORTED_FIGURE_SUMMARY_MIME_TYPES:
+            raise ValueError(
+                f"Unsupported figure mime type: {mime_type}. "
+                "Allowed figure types are png, jpeg, gif, webp, and svg."
+            )
+        try:
+            raw = base64.b64decode(
+                str(data_base64 or "").encode("ascii"), validate=True
+            )
+        except (binascii.Error, UnicodeEncodeError) as exc:
+            raise ValueError("Figure data_base64 must be valid base64.") from exc
+        if not raw:
+            raise ValueError("Figure image data is empty.")
+        if len(raw) > cls._MAX_FIGURE_SUMMARY_BYTES:
+            raise ValueError(
+                "Figure image is too large to summarize safely "
+                f"({len(raw)} bytes; limit {cls._MAX_FIGURE_SUMMARY_BYTES} bytes)."
+            )
+        return normalized_mime, base64.b64encode(raw).decode("ascii")
+
     def summarize_figure(self, mime_type: str, data_base64: str) -> AIResult:
+        normalized_mime, normalized_base64 = self._prepare_figure_summary_input(
+            mime_type, data_base64
+        )
         client = self._client()
         system_prompt = (
             "You write concise figure summaries for a physics exam author. "
@@ -274,7 +312,7 @@ class AIService:
                         {"type": "input_text", "text": user_prompt},
                         {
                             "type": "input_image",
-                            "image_url": f"data:{mime_type};base64,{data_base64}",
+                            "image_url": f"data:{normalized_mime};base64,{normalized_base64}",
                             "detail": "low",
                         },
                     ],

--- a/src/exam_helper/ai_service.py
+++ b/src/exam_helper/ai_service.py
@@ -250,6 +250,42 @@ class AIService:
             f"- {item}" for item in summaries
         )
 
+    def summarize_figure(self, mime_type: str, data_base64: str) -> AIResult:
+        client = self._client()
+        system_prompt = (
+            "You write concise figure summaries for a physics exam author. "
+            "Return plain text only, with one short sentence."
+        )
+        user_prompt = (
+            "Summarize the attached figure for the question author in one short "
+            "sentence. Mention the important objects, labels, and relationships. "
+            "Return plain text only."
+        )
+        response = client.responses.create(
+            model=self.model,
+            input=[
+                {
+                    "role": "system",
+                    "content": [{"type": "input_text", "text": system_prompt}],
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "input_text", "text": user_prompt},
+                        {
+                            "type": "input_image",
+                            "image_url": f"data:{mime_type};base64,{data_base64}",
+                            "detail": "low",
+                        },
+                    ],
+                },
+            ],
+        )
+        text = getattr(response, "output_text", "").strip()
+        if not text:
+            raise ValueError("Empty AI response.")
+        return AIService.AIResult(text=text, usage=self._usage_from_response(response))
+
     @staticmethod
     def _editor_state_for_question(
         question: Question,

--- a/src/exam_helper/app.py
+++ b/src/exam_helper/app.py
@@ -918,6 +918,24 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
         raw = base64.b64decode(data_base64.encode("ascii"))
         return {"sha256": sha256(raw).hexdigest(), "size": len(raw)}
 
+    @app.post("/figures/summarize", response_model=None)
+    def summarize_figure(
+        data_base64: str = Form(...), mime_type: str = Form("image/png")
+    ) -> Any:
+        try:
+            result = app.state.ai.summarize_figure(
+                mime_type=mime_type, data_base64=data_base64
+            )
+            repo.add_ai_usage(result.usage)
+            return {"summary": result.text}
+        except Exception as ex:
+            logger.exception(
+                "figure.summarize failed mime_type=%s size=%s",
+                mime_type,
+                len(data_base64 or ""),
+            )
+            return JSONResponse({"ok": False, "error": str(ex)}, status_code=422)
+
     @app.post("/questions/{question_id}/validate")
     def validate_question_endpoint(question_id: str) -> dict:
         q = repo.get_question(question_id)

--- a/src/exam_helper/app.py
+++ b/src/exam_helper/app.py
@@ -923,8 +923,11 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
         data_base64: str = Form(...), mime_type: str = Form("image/png")
     ) -> Any:
         try:
+            normalized_mime, normalized_data = AIService._prepare_figure_summary_input(
+                mime_type, data_base64
+            )
             result = app.state.ai.summarize_figure(
-                mime_type=mime_type, data_base64=data_base64
+                mime_type=normalized_mime, data_base64=normalized_data
             )
             repo.add_ai_usage(result.usage)
             return {"summary": result.text}

--- a/src/exam_helper/templates/question_form_v2.html
+++ b/src/exam_helper/templates/question_form_v2.html
@@ -847,6 +847,49 @@
         return figureId ? figureUrl(figureId) : "#";
       }
 
+      const SUPPORTED_FIGURE_FILE_TYPES = [
+        { extension: "png", mime_type: "image/png" },
+        { extension: "jpg", mime_type: "image/jpeg" },
+        { extension: "jpeg", mime_type: "image/jpeg" },
+        { extension: "gif", mime_type: "image/gif" },
+        { extension: "webp", mime_type: "image/webp" },
+        { extension: "svg", mime_type: "image/svg+xml" },
+      ];
+      const SUPPORTED_FIGURE_MIME_TYPES = new Set(
+        SUPPORTED_FIGURE_FILE_TYPES.map((item) => item.mime_type)
+      );
+
+      function fileExtensionFromName(name) {
+        const lower = String(name || "").trim().toLowerCase();
+        const match = lower.match(/\.([a-z0-9]+)$/);
+        return match ? match[1] : "";
+      }
+
+      function figureFileTypeFromFile(file) {
+        const mimeType = String(file?.type || "").trim().toLowerCase();
+        if (mimeType) {
+          return SUPPORTED_FIGURE_MIME_TYPES.has(mimeType)
+            ? SUPPORTED_FIGURE_FILE_TYPES.find((item) => item.mime_type === mimeType)
+            : null;
+        }
+        const ext = fileExtensionFromName(file?.name || "");
+        return (
+          SUPPORTED_FIGURE_FILE_TYPES.find((item) => item.extension === ext) || null
+        );
+      }
+
+      function isSupportedFigureFile(file) {
+        return figureFileTypeFromFile(file) !== null;
+      }
+
+      function figureMimeTypeFromFile(file) {
+        return figureFileTypeFromFile(file)?.mime_type || "image/png";
+      }
+
+      function allowedFigureFileList() {
+        return SUPPORTED_FIGURE_FILE_TYPES.map((item) => `.${item.extension}`).join(", ");
+      }
+
       function clearFigureNotice() {
         if (figureNoticeTimer) {
           window.clearTimeout(figureNoticeTimer);
@@ -859,16 +902,43 @@
         figureNoticeEl.textContent = "";
       }
 
-      function showFigureNotice(message) {
+      function showFigureNotice(message, options = {}) {
         if (!figureNoticeEl) {
           return;
         }
         clearFigureNotice();
         figureNoticeEl.textContent = message;
         figureNoticeEl.classList.add("is-visible");
-        figureNoticeTimer = window.setTimeout(() => {
-          clearFigureNotice();
-        }, 6000);
+        const timeoutMs = options.timeoutMs === undefined ? 6000 : options.timeoutMs;
+        if (timeoutMs !== null) {
+          figureNoticeTimer = window.setTimeout(() => {
+            clearFigureNotice();
+          }, timeoutMs);
+        }
+      }
+
+      function summarizeRejectedFigureFiles(files) {
+        const names = files
+          .map((file) => String(file?.name || "unnamed file").trim())
+          .filter(Boolean)
+          .slice(0, 5);
+        const prefix = names.length
+          ? `Ignored ${names.join(", ")}.`
+          : "Ignored unsupported file.";
+        return `${prefix} Allowed figure files: ${allowedFigureFileList()}.`;
+      }
+
+      function splitSupportedFigureFiles(files) {
+        const valid = [];
+        const rejected = [];
+        for (const file of files || []) {
+          if (isSupportedFigureFile(file)) {
+            valid.push(file);
+          } else {
+            rejected.push(file);
+          }
+        }
+        return { valid, rejected };
       }
 
       async function summarizeFigureData(mimeType, dataBase64) {
@@ -980,7 +1050,7 @@
       }
 
       async function buildFigureFromFile(file) {
-        const mime = String(file.type || "").startsWith("image/") ? file.type : "image/png";
+        const mime = figureMimeTypeFromFile(file);
         const buf = await file.arrayBuffer();
         const dataBase64 = arrayBufferToBase64(buf);
         const validated = await validateFigureData(dataBase64);
@@ -993,12 +1063,12 @@
       }
 
       async function addFigureFromFile(file, fallbackAppend = true) {
-        if (!file || !String(file.type || "").startsWith("image/")) return false;
+        if (!file || !isSupportedFigureFile(file)) return false;
         const figures = parseFigures();
         const pendingId = nextFigureId(figures);
         setStatus("Processing image...", "warn");
         const figure = await buildFigureFromFile(file);
-        showFigureNotice("Generating figure summary...");
+        showFigureNotice("Generating figure summary...", { timeoutMs: null });
         try {
           figure.caption = await summarizeFigureData(figure.mime_type, figure.data_base64);
           clearFigureNotice();
@@ -1017,12 +1087,12 @@
       }
 
       async function addChatAttachmentFromFile(file) {
-        if (!file || !String(file.type || "").startsWith("image/")) return false;
+        if (!file || !isSupportedFigureFile(file)) return false;
         const figures = parseFigures();
         const pendingId = nextFigureId(figures);
         setChatStatus("Processing chat image...", "warn");
         const figure = await buildFigureFromFile(file);
-        showFigureNotice("Generating figure summary...");
+        showFigureNotice("Generating figure summary...", { timeoutMs: null });
         try {
           figure.caption = await summarizeFigureData(figure.mime_type, figure.data_base64);
           clearFigureNotice();
@@ -1050,6 +1120,26 @@
           }
         }
         return files;
+      }
+
+      function addFigureFiles(files, fallbackAppend = true) {
+        const { valid, rejected } = splitSupportedFigureFiles(files);
+        if (rejected.length) {
+          showFigureNotice(summarizeRejectedFigureFiles(rejected));
+        }
+        return Promise.all(
+          valid.map((file) => addFigureFromFile(file, fallbackAppend))
+        ).then((results) => results.some(Boolean));
+      }
+
+      function addChatFigureFiles(files) {
+        const { valid, rejected } = splitSupportedFigureFiles(files);
+        if (rejected.length) {
+          setChatStatus(summarizeRejectedFigureFiles(rejected), "warn");
+        }
+        return Promise.all(valid.map((file) => addChatAttachmentFromFile(file))).then(
+          (results) => results.some(Boolean)
+        );
       }
 
       function renderTemplate() {
@@ -1378,14 +1468,13 @@
       addFigureBtn.addEventListener("click", () => {
         figureFileInput.click();
       });
+      figureFileInput.accept = allowedFigureFileList();
 
       figureFileInput.addEventListener("change", async () => {
         const files = Array.from(figureFileInput.files || []);
         if (!files.length) return;
         try {
-          for (const file of files) {
-            await addFigureFromFile(file, true);
-          }
+          await addFigureFiles(files, true);
         } catch (err) {
           setStatus(`Image error: ${err.message}`, "warn");
         } finally {
@@ -1416,9 +1505,7 @@
         if (!files.length) return;
         event.preventDefault();
         try {
-          for (const file of files) {
-            await addFigureFromFile(file, false);
-          }
+          await addFigureFiles(files, false);
         } catch (err) {
           setStatus(`Image paste error: ${err.message}`, "warn");
         }
@@ -1429,9 +1516,7 @@
         if (!files.length) return;
         event.preventDefault();
         try {
-          for (const file of files) {
-            await addChatAttachmentFromFile(file);
-          }
+          await addChatFigureFiles(files);
         } catch (err) {
           setChatStatus(`Chat image error: ${err.message}`, "warn");
         }
@@ -1451,21 +1536,17 @@
 
       document.addEventListener("drop", async (event) => {
         figuresSectionEl.style.borderColor = "";
-        const files = Array.from(event.dataTransfer?.files || []).filter((f) => String(f.type || "").startsWith("image/"));
+        const files = Array.from(event.dataTransfer?.files || []);
         if (!files.length) return;
         event.preventDefault();
         try {
           const dropTarget = event.target instanceof Element ? event.target.closest(".chat-panel") : null;
           if (dropTarget) {
-            for (const file of files) {
-              await addChatAttachmentFromFile(file);
-            }
+            await addChatFigureFiles(files);
             return;
           }
           const appendFallback = document.activeElement !== templateEl;
-          for (const file of files) {
-            await addFigureFromFile(file, appendFallback);
-          }
+          await addFigureFiles(files, appendFallback);
         } catch (err) {
           setStatus(`Image drop error: ${err.message}`, "warn");
         }

--- a/src/exam_helper/templates/question_form_v2.html
+++ b/src/exam_helper/templates/question_form_v2.html
@@ -204,6 +204,26 @@
       .figure-preview-button img {
         cursor: zoom-in;
       }
+      #figures_section {
+        position: relative;
+      }
+      .figure-notice {
+        display: none;
+        position: absolute;
+        top: 4rem;
+        right: 1rem;
+        max-width: min(30rem, calc(100% - 2rem));
+        padding: 0.75rem 0.9rem;
+        border-radius: 14px;
+        border: 1px solid #a5b4fc;
+        background: #eef2ff;
+        color: #312e81;
+        box-shadow: 0 12px 24px rgba(90, 64, 28, 0.12);
+        z-index: 1;
+      }
+      .figure-notice.is-visible {
+        display: block;
+      }
       .figure-meta {
         font-size: 0.92rem;
         color: var(--muted);
@@ -251,6 +271,10 @@
       .figure-modal__meta {
         color: var(--muted);
         font-size: 0.95rem;
+      }
+      .figure-modal__summary {
+        color: var(--text);
+        font-weight: 700;
       }
       .figure-modal__close {
         justify-self: end;
@@ -566,6 +590,7 @@
           <label>Figures (embedded)</label>
           <p class="hint">Paste into Question Template, drag/drop onto the page, or add image files here. The image data stays in the question YAML.</p>
           <button type="button" class="btn btn-secondary" id="btn_add_figure">Add Image File</button>
+          <div id="figure_notice" class="figure-notice" role="status" aria-live="polite"></div>
           <input type="file" id="figure_file_input" accept="image/*" multiple style="display:none;" />
           <input type="hidden" id="figures_json" name="figures_json" value='{{ figures_json }}' />
           <div id="figures_preview">
@@ -578,7 +603,7 @@
                 <div>
                   <strong>{{ figure.id }}</strong>
                   <div class="figure-meta">{{ figure.mime_type }} · {{ figure.data_base64 | length }} base64 chars</div>
-                  <div class="figure-meta">{{ figure.caption or "No caption" }}</div>
+                  <div class="figure-meta">Summary: {{ figure.caption or "No summary yet" }}</div>
                 </div>
                 <button type="button" class="btn btn-secondary" data-remove-figure="{{ loop.index0 }}">Remove</button>
               </div>
@@ -593,6 +618,7 @@
             <h3 id="figure_modal_title">Figure preview</h3>
             <img id="figure_modal_image" alt="" />
             <div id="figure_modal_meta" class="figure-modal__meta"></div>
+            <div id="figure_modal_summary" class="figure-modal__summary"></div>
           </div>
         </div>
 
@@ -662,9 +688,11 @@
       const figureModalTitleEl = document.getElementById("figure_modal_title");
       const figureModalImageEl = document.getElementById("figure_modal_image");
       const figureModalMetaEl = document.getElementById("figure_modal_meta");
+      const figureModalSummaryEl = document.getElementById("figure_modal_summary");
       const figureModalCloseEl = document.getElementById("figure_modal_close");
       const addFigureBtn = document.getElementById("btn_add_figure");
       const figureFileInput = document.getElementById("figure_file_input");
+      const figureNoticeEl = document.getElementById("figure_notice");
       const promptPreview = document.getElementById("prompt_preview");
       const mcBlock = document.getElementById("mc_block");
       const mcPreviewAnswers = document.getElementById("mc_preview_answers");
@@ -682,6 +710,7 @@
       let autosaveTimer = null;
       let pendingChatFigureIds = [];
       let figureModalLastFocus = null;
+      let figureNoticeTimer = null;
 
       function setStatus(text, cls) {
         saveStatus.textContent = text;
@@ -818,6 +847,42 @@
         return figureId ? figureUrl(figureId) : "#";
       }
 
+      function clearFigureNotice() {
+        if (figureNoticeTimer) {
+          window.clearTimeout(figureNoticeTimer);
+          figureNoticeTimer = null;
+        }
+        if (!figureNoticeEl) {
+          return;
+        }
+        figureNoticeEl.classList.remove("is-visible");
+        figureNoticeEl.textContent = "";
+      }
+
+      function showFigureNotice(message) {
+        if (!figureNoticeEl) {
+          return;
+        }
+        clearFigureNotice();
+        figureNoticeEl.textContent = message;
+        figureNoticeEl.classList.add("is-visible");
+        figureNoticeTimer = window.setTimeout(() => {
+          clearFigureNotice();
+        }, 6000);
+      }
+
+      async function summarizeFigureData(mimeType, dataBase64) {
+        const body = new FormData();
+        body.append("mime_type", mimeType);
+        body.append("data_base64", dataBase64);
+        const res = await fetch("/figures/summarize", { method: "POST", body });
+        const data = await res.json();
+        if (!res.ok) {
+          throw new Error(data.error || res.statusText || "Figure summary failed.");
+        }
+        return String(data.summary || "").trim();
+      }
+
       function renderFiguresPreview() {
         const figures = parseFigures();
         if (!figures.length) {
@@ -834,7 +899,7 @@
             `<button type="button" class="figure-preview-button" data-open-figure="${idx}" aria-label="Open full-size preview of ${figureId}">` +
             `<img src="${escapeHtml(figurePreviewSrc(figure, figure.id || `fig_${idx + 1}`))}" alt="${figureId}" />` +
             `</button>` +
-            `<div><strong>${figureId}</strong><div class="figure-meta">${mimeType} · ${dataSize} base64 chars</div><div class="figure-meta">${caption || "No caption"}</div></div>` +
+            `<div><strong>${figureId}</strong><div class="figure-meta">${mimeType} · ${dataSize} base64 chars</div><div class="figure-meta">Summary: ${caption || "No summary yet"}</div></div>` +
             `<button type="button" class="btn btn-secondary" data-remove-figure="${idx}">Remove</button>` +
             `</div>`
           );
@@ -848,6 +913,7 @@
         figureModalImageEl.alt = "";
         figureModalTitleEl.textContent = "Figure preview";
         figureModalMetaEl.textContent = "";
+        figureModalSummaryEl.textContent = "";
         if (figureModalLastFocus && typeof figureModalLastFocus.focus === "function") {
           figureModalLastFocus.focus();
         }
@@ -865,7 +931,8 @@
         figureModalTitleEl.textContent = figureId;
         figureModalImageEl.src = figurePreviewSrc(figure, figureId);
         figureModalImageEl.alt = caption ? `${figureId}: ${caption}` : figureId;
-        figureModalMetaEl.textContent = `${mimeType} · ${dataSize} base64 chars${caption ? ` · ${caption}` : ""}`;
+        figureModalMetaEl.textContent = `${mimeType} · ${dataSize} base64 chars`;
+        figureModalSummaryEl.textContent = `Summary: ${caption || "No summary yet"}`;
         figureModalLastFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null;
         figureModalEl.classList.add("is-open");
         figureModalEl.setAttribute("aria-hidden", "false");
@@ -931,6 +998,14 @@
         const pendingId = nextFigureId(figures);
         setStatus("Processing image...", "warn");
         const figure = await buildFigureFromFile(file);
+        showFigureNotice("Generating figure summary...");
+        try {
+          figure.caption = await summarizeFigureData(figure.mime_type, figure.data_base64);
+          clearFigureNotice();
+        } catch (err) {
+          figure.caption = "";
+          showFigureNotice(`Figure added without AI summary: ${err.message}`);
+        }
         figure.id = pendingId;
         figures.push(figure);
         setFigures(figures);
@@ -947,6 +1022,14 @@
         const pendingId = nextFigureId(figures);
         setChatStatus("Processing chat image...", "warn");
         const figure = await buildFigureFromFile(file);
+        showFigureNotice("Generating figure summary...");
+        try {
+          figure.caption = await summarizeFigureData(figure.mime_type, figure.data_base64);
+          clearFigureNotice();
+        } catch (err) {
+          figure.caption = "";
+          showFigureNotice(`Figure added without AI summary: ${err.message}`);
+        }
         figure.id = pendingId;
         figures.push(figure);
         setFigures(figures);

--- a/tests/integration/test_app_question_save.py
+++ b/tests/integration/test_app_question_save.py
@@ -96,6 +96,21 @@ def test_summarize_figure_endpoint_returns_summary(tmp_path) -> None:
     assert payload["summary"] == "A block on an incline plane."
 
 
+def test_summarize_figure_endpoint_rejects_invalid_inputs(tmp_path) -> None:
+    repo = ProjectRepository(tmp_path)
+    repo.init_project("Exam", "Physics")
+    app = create_app(tmp_path, openai_key="k")
+    client = TestClient(app)
+
+    resp = client.post(
+        "/figures/summarize",
+        data={"data_base64": "aGVsbG8=", "mime_type": "text/plain"},
+    )
+    assert resp.status_code == 422
+    payload = resp.json()
+    assert "Unsupported figure mime type" in payload["error"]
+
+
 def test_embedded_figure_route_serves_question_figure_bytes(tmp_path) -> None:
     repo = ProjectRepository(tmp_path)
     repo.init_project("Exam", "Physics")

--- a/tests/integration/test_app_question_save.py
+++ b/tests/integration/test_app_question_save.py
@@ -6,7 +6,9 @@ import yaml
 
 from fastapi.testclient import TestClient
 
+from exam_helper.ai_service import AIService
 from exam_helper.app import create_app
+from exam_helper.models import AIUsageTotals
 from exam_helper.repository import ProjectRepository
 
 
@@ -65,6 +67,35 @@ def test_validate_figure_endpoint_returns_hash_and_size(tmp_path) -> None:
     assert payload["size"] == len(raw)
 
 
+def test_summarize_figure_endpoint_returns_summary(tmp_path) -> None:
+    repo = ProjectRepository(tmp_path)
+    repo.init_project("Exam", "Physics")
+    app = create_app(tmp_path, openai_key="k")
+
+    class FakeAI:
+        def summarize_figure(self, *, mime_type: str, data_base64: str):
+            assert mime_type == "image/png"
+            assert data_base64 == b64
+            return AIService.AIResult(
+                text="A block on an incline plane.",
+                usage=AIUsageTotals(),
+            )
+
+    app.state.ai = FakeAI()
+    client = TestClient(app)
+
+    raw = b"png-bytes"
+    b64 = base64.b64encode(raw).decode("ascii")
+
+    resp = client.post(
+        "/figures/summarize",
+        data={"data_base64": b64, "mime_type": "image/png"},
+    )
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["summary"] == "A block on an incline plane."
+
+
 def test_embedded_figure_route_serves_question_figure_bytes(tmp_path) -> None:
     repo = ProjectRepository(tmp_path)
     repo.init_project("Exam", "Physics")
@@ -117,6 +148,7 @@ def test_new_question_page_contains_figure_upload_controls(tmp_path) -> None:
     assert 'id="figures_preview"' in html
     assert 'id="btn_add_figure"' in html
     assert 'id="figure_file_input"' in html
+    assert 'id="figure_notice"' in html
 
     redirect = client.get("/questions/new", follow_redirects=False)
     assert redirect.status_code == 303
@@ -212,6 +244,7 @@ def test_edit_existing_question_save_preserves_legacy_fields(tmp_path) -> None:
     assert 'name="include_solutions"' in edit_html
     assert "/questions/legacy-editor/fig_1" in edit_html
     assert 'data-open-figure="0"' in edit_html
+    assert "Summary:" in edit_html
 
     save_resp = client.post(
         "/questions/save",

--- a/tests/unit/test_ai_service.py
+++ b/tests/unit/test_ai_service.py
@@ -228,6 +228,24 @@ def test_ai_service_summarize_figure(monkeypatch) -> None:
     )
 
 
+def test_ai_service_summarize_figure_rejects_invalid_inputs() -> None:
+    svc = AIService(api_key="k")
+
+    try:
+        svc.summarize_figure("text/plain", "aGVsbG8=")
+    except ValueError as ex:
+        assert "Unsupported figure mime type" in str(ex)
+    else:
+        raise AssertionError("summarize_figure should reject unsupported mime types")
+
+    try:
+        svc.summarize_figure("image/png", "not-base64")
+    except ValueError as ex:
+        assert "valid base64" in str(ex)
+    else:
+        raise AssertionError("summarize_figure should reject invalid base64")
+
+
 def test_usage_parses_total_cost_from_formatted_string() -> None:
     svc = AIService(api_key="k")
 

--- a/tests/unit/test_ai_service.py
+++ b/tests/unit/test_ai_service.py
@@ -189,6 +189,45 @@ def test_ai_service_generate_distractor_functions(monkeypatch) -> None:
     assert len(out.distractors) == 4
 
 
+def test_ai_service_summarize_figure(monkeypatch) -> None:
+    from exam_helper import ai_service as mod
+
+    class _RecordingResponses:
+        def __init__(self):
+            self.calls = []
+
+        def create(self, **kwargs):
+            self.calls.append(kwargs)
+
+            class R:
+                pass
+
+            r = R()
+            r.output_text = "A block slides down an incline."
+            r.output = []
+            r.id = "resp_1"
+            return r
+
+    class _RecordingClient:
+        def __init__(self):
+            self.responses = _RecordingResponses()
+
+    recording_client = _RecordingClient()
+    monkeypatch.setattr(mod, "OpenAI", lambda api_key: recording_client)
+    svc = AIService(api_key="k")
+
+    out = svc.summarize_figure("image/png", "aGVsbG8=")
+
+    assert out.text == "A block slides down an incline."
+    call = recording_client.responses.calls[0]
+    assert call["input"][0]["content"][0]["text"].startswith(
+        "You write concise figure summaries"
+    )
+    assert call["input"][1]["content"][1]["image_url"].startswith(
+        "data:image/png;base64,"
+    )
+
+
 def test_usage_parses_total_cost_from_formatted_string() -> None:
     svc = AIService(api_key="k")
 


### PR DESCRIPTION
Fixes #109
Fixes #107

- Add an AI-backed `/figures/summarize` endpoint and call it during figure upload so the generated summary is stored with the figure caption.
- Show a short in-page notice while the summary is being generated.
- Render the saved figure summary explicitly in the figure list and modal so authors see it when reopening the image.
- Add coverage for the figure-summary endpoint and the AI service request path.

Validation:
- `uv run --extra dev pytest -q tests/unit/test_ai_service.py tests/integration/test_app_question_save.py -k "summarize or figure or embedded_figure_route or create_question_with_embedded_figure or validate_figure_endpoint_returns_hash_and_size"`
- `uv run --extra dev black --check src/exam_helper/ai_service.py src/exam_helper/app.py tests/unit/test_ai_service.py tests/integration/test_app_question_save.py`

Remaining risk:
- The upload-time AI summary is best-effort; if the model is unavailable, the figure still saves but the summary field remains empty.