### PR TITLE
Remove legacy `/questions/new2` route

### DIFF
--- a/src/exam_helper/app.py
+++ b/src/exam_helper/app.py
@@ -808,10 +808,6 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
 
     @app.get("/questions/new", response_class=HTMLResponse)
     def new_question(request: Request) -> HTMLResponse:
-        return RedirectResponse("/questions/new2", status_code=303)
-
-    @app.get("/questions/new2", response_class=HTMLResponse)
-    def new_question_v2(request: Request) -> HTMLResponse:
         return templates.TemplateResponse(
             request,
             "question_form_v2.html",

--- a/src/exam_helper/templates/index.html
+++ b/src/exam_helper/templates/index.html
@@ -74,7 +74,7 @@
     {% endif %}
 
     <div class="controls">
-      <a class="btn" href="/questions/new2">New Question</a>
+      <a class="btn" href="/questions/new">New Question</a>
       <form class="export-form" method="post" action="/export/docx">
         <button class="btn" type="submit">Export DOCX</button>
         <label><input type="checkbox" name="include_solutions" value="1" /> Include solutions</label>

--- a/tests/integration/test_app_question_save.py
+++ b/tests/integration/test_app_question_save.py
@@ -156,7 +156,7 @@ def test_new_question_page_contains_figure_upload_controls(tmp_path) -> None:
     app = create_app(tmp_path, openai_key=None)
     client = TestClient(app)
 
-    resp = client.get("/questions/new2")
+    resp = client.get("/questions/new")
     assert resp.status_code == 200
     html = resp.text
     assert 'id="figures_json"' in html
@@ -166,18 +166,14 @@ def test_new_question_page_contains_figure_upload_controls(tmp_path) -> None:
     assert 'id="figure_notice"' in html
     assert 'accept="image/*,.svg"' in html
 
-    redirect = client.get("/questions/new", follow_redirects=False)
-    assert redirect.status_code == 303
-    assert redirect.headers["location"] == "/questions/new2"
 
-
-def test_new_question_2_page_contains_simplified_editor(tmp_path) -> None:
+def test_new_question_page_contains_simplified_editor(tmp_path) -> None:
     repo = ProjectRepository(tmp_path)
     repo.init_project("Exam", "Physics")
     app = create_app(tmp_path, openai_key=None)
     client = TestClient(app)
 
-    resp = client.get("/questions/new2")
+    resp = client.get("/questions/new")
     assert resp.status_code == 200
     html = resp.text
     assert "<title>Question Editor - New Question</title>" in html
@@ -397,7 +393,7 @@ def test_new_question_id_skips_soft_deleted_ids(tmp_path) -> None:
     assert 'id="question_id" value="q2"' in new_page.text
 
 
-def test_home_shows_edit_and_new_question_2_links(tmp_path) -> None:
+def test_home_shows_edit_and_new_question_links(tmp_path) -> None:
     repo = ProjectRepository(tmp_path)
     repo.init_project("Exam", "Physics")
     app = create_app(tmp_path, openai_key=None)
@@ -421,9 +417,8 @@ def test_home_shows_edit_and_new_question_2_links(tmp_path) -> None:
 
     home = client.get("/")
     assert home.status_code == 200
-    assert 'href="/questions/new2"' in home.text
+    assert 'href="/questions/new"' in home.text
     assert 'href="/questions/q1/edit"' in home.text
-    assert 'href="/questions/new"' not in home.text
 
 
 def test_save_persists_dollar_math_delimiters(tmp_path) -> None:


### PR DESCRIPTION
Fixes #114

- Remove the legacy `/questions/new2` route and make `/questions/new` serve the new-question editor directly.
- Update the home page link and regression tests to use the canonical URL.

Validation:
- `uv run --extra dev pytest -q tests/integration/test_app_question_save.py`
- `uv run --extra dev pytest -q`
- `uv run --extra dev black --check src/exam_helper/app.py tests/integration/test_app_question_save.py`

Remaining risk:
- None identified; this change only removes the legacy redirect path and updates the tests to match.