### PR TITLE
Define the chat history keep-count helper

### DIFF
--- a/src/exam_helper/templates/question_form_v2.html
+++ b/src/exam_helper/templates/question_form_v2.html
@@ -751,6 +751,11 @@
         chatSendBtn.textContent = isBusy ? "Sending..." : "Send";
       }
 
+      function chatHistoryKeepCount() {
+        const parsed = Number.parseInt(chatHistoryKeepCountEl.value, 10);
+        return Number.isFinite(parsed) && parsed >= 0 ? parsed : 5;
+      }
+
       function escapeHtml(text) {
         return String(text || "")
           .replace(/&/g, "&amp;")

--- a/tests/integration/test_app_ai_config_and_usage.py
+++ b/tests/integration/test_app_ai_config_and_usage.py
@@ -67,6 +67,7 @@ def test_question_editor_has_chat_workflow_hooks(tmp_path) -> None:
     assert "<summary>Chat Assistant</summary>" in resp.text
     assert 'id="chat_thread"' in resp.text
     assert 'id="chat_history_keep_count"' in resp.text
+    assert "function chatHistoryKeepCount()" in resp.text
     assert (
         'title="Set to 0 to send the full chat history back to the LLM."' in resp.text
     )


### PR DESCRIPTION
Fixes #115

- Add the missing `chatHistoryKeepCount()` helper in the question editor so the chat send path can read the history window without throwing.
- Add a regression assertion that the rendered editor includes the helper definition.

Validation:
- `uv run --extra dev pytest -q tests/integration/test_app_ai_config_and_usage.py tests/integration/test_autosave_and_ai_errors.py -k chat`
- `uv run --extra dev pytest -q`
- `uv run --extra dev black --check tests/integration/test_app_ai_config_and_usage.py`

Remaining risk:
- The coverage is a rendered-template assertion rather than a live browser click test, but it directly guards the missing helper that caused the runtime failure.