### PR TITLE
Restore editor state rendering helper

### DIFF
--- a/src/exam_helper/templates/question_form_v2.html
+++ b/src/exam_helper/templates/question_form_v2.html
@@ -840,6 +840,15 @@
         }
       }
 
+      function parseChatHistory() {
+        try {
+          const parsed = JSON.parse(chatHistoryEl.value || "[]");
+          return Array.isArray(parsed) ? parsed : [];
+        } catch {
+          return [];
+        }
+      }
+
       function setFigures(figures) {
         figuresInput.value = JSON.stringify(figures);
         editorState = normalizeEditorState({ ...editorState, figures_json: figuresInput.value });

--- a/src/exam_helper/templates/question_form_v2.html
+++ b/src/exam_helper/templates/question_form_v2.html
@@ -1486,6 +1486,10 @@
         mcBlock.style.display = isMC() ? "block" : "none";
       }
 
+      function isMC() {
+        return questionTypeEl.value === "multiple_choice";
+      }
+
       function serializePayload() {
         return { ...collectEditorStateFromDOM() };
       }

--- a/src/exam_helper/templates/question_form_v2.html
+++ b/src/exam_helper/templates/question_form_v2.html
@@ -1321,6 +1321,45 @@
         }
       }
 
+      function renderEditorState(data = {}) {
+        const nextState = data.editor_state || { ...editorState, ...data };
+        editorState = normalizeEditorState(nextState);
+        titleEl.value = editorState.title;
+        pointsEl.value = editorState.points;
+        questionTypeEl.value = editorState.question_type;
+        templateEl.value = editorState.question_template_md;
+        paramsEl.value = editorState.solution_parameters_yaml;
+        answerFormulaEl.value = editorState.answer_formula_md;
+        answerGuidanceEl.value = editorState.answer_guidance;
+        mcOptionsGuidanceEl.value = editorState.mc_options_guidance;
+        distractorFnsEl.value = editorState.distractor_functions_text;
+        mcAnswerSpecsEl.value = editorState.mc_answer_specs_json;
+        choicesYamlEl.value = editorState.choices_yaml;
+        typedSolutionEl.value = editorState.typed_solution_md;
+        typedStatusEl.value = editorState.typed_solution_status;
+        chatHistoryEl.value = editorState.chat_history_json;
+        figuresInput.value = editorState.figures_json;
+        syncMCRowsFromSpecs(parseMCSpecs());
+        if (typeof data.calculated_variables_md === "string") {
+          calculatedVariablesEl.textContent = data.calculated_variables_md;
+        }
+        answerFormulaWarningEl.textContent = data.warning || data.answer_formula_warning
+          ? `Warning: ${data.warning || data.answer_formula_warning}`
+          : "";
+        renderTemplate();
+        renderMCPreviewFromData(data);
+        renderFiguresPreview();
+        renderChatHistory();
+        if (typeof data.rendered_answer_md === "string") {
+          renderMarkdownSurface(renderedAnswerEl, data.rendered_answer_md);
+        }
+        updateMCVisibility();
+      }
+
+      function setEditorValuesFromResponse(data) {
+        renderEditorState(data);
+      }
+
       function renderMarkdownSurface(el, markdown) {
         el.innerHTML = marked.parse(normalizeMathDelimitersForPreview(markdown || ""));
         if (window.MathJax && window.MathJax.typesetPromise) {

--- a/tests/integration/test_app_question_save.py
+++ b/tests/integration/test_app_question_save.py
@@ -192,6 +192,7 @@ def test_new_question_page_contains_simplified_editor(tmp_path) -> None:
     assert 'class="mc-preview-text"' in html
     assert "function isMC(" in html
     assert "function renderEditorState(" in html
+    assert "function parseChatHistory(" in html
     assert 'id="btn_rewrite"' not in html
     assert 'id="btn_generate_answer"' not in html
     assert '<option value="multiple_choice" selected>' in html
@@ -255,6 +256,7 @@ def test_edit_existing_question_save_preserves_legacy_fields(tmp_path) -> None:
     assert 'id="mc_preview_rationale"' in edit_html
     assert "function isMC(" in edit_html
     assert "function renderEditorState(" in edit_html
+    assert "function parseChatHistory(" in edit_html
     assert "Export this question to DOCX" in edit_html
     assert 'formaction="/questions/legacy-editor/export/docx"' in edit_html
     assert 'name="include_solutions"' in edit_html

--- a/tests/integration/test_app_question_save.py
+++ b/tests/integration/test_app_question_save.py
@@ -190,6 +190,7 @@ def test_new_question_page_contains_simplified_editor(tmp_path) -> None:
     assert 'id="mc_preview_answers"' in html
     assert 'id="mc_preview_rationale"' in html
     assert 'class="mc-preview-text"' in html
+    assert "function isMC(" in html
     assert "function renderEditorState(" in html
     assert 'id="btn_rewrite"' not in html
     assert 'id="btn_generate_answer"' not in html
@@ -252,6 +253,7 @@ def test_edit_existing_question_save_preserves_legacy_fields(tmp_path) -> None:
     assert 'id="rendered_answer_md"' in edit_html
     assert 'id="mc_preview_answers"' in edit_html
     assert 'id="mc_preview_rationale"' in edit_html
+    assert "function isMC(" in edit_html
     assert "function renderEditorState(" in edit_html
     assert "Export this question to DOCX" in edit_html
     assert 'formaction="/questions/legacy-editor/export/docx"' in edit_html

--- a/tests/integration/test_app_question_save.py
+++ b/tests/integration/test_app_question_save.py
@@ -190,6 +190,7 @@ def test_new_question_page_contains_simplified_editor(tmp_path) -> None:
     assert 'id="mc_preview_answers"' in html
     assert 'id="mc_preview_rationale"' in html
     assert 'class="mc-preview-text"' in html
+    assert "function renderEditorState(" in html
     assert 'id="btn_rewrite"' not in html
     assert 'id="btn_generate_answer"' not in html
     assert '<option value="multiple_choice" selected>' in html
@@ -251,6 +252,7 @@ def test_edit_existing_question_save_preserves_legacy_fields(tmp_path) -> None:
     assert 'id="rendered_answer_md"' in edit_html
     assert 'id="mc_preview_answers"' in edit_html
     assert 'id="mc_preview_rationale"' in edit_html
+    assert "function renderEditorState(" in edit_html
     assert "Export this question to DOCX" in edit_html
     assert 'formaction="/questions/legacy-editor/export/docx"' in edit_html
     assert 'name="include_solutions"' in edit_html


### PR DESCRIPTION
Fixes #118
Fixes #122
Fixes #124

- Restore the missing `renderEditorState` helper in the question editor template.
- Restore the `setEditorValuesFromResponse` compatibility alias used by the browser test harness.
- Restore the missing `isMC()` helper so multiple-choice rendering and autosave logic work during AI chat updates.
- Restore the missing `parseChatHistory()` helper so chat history renders correctly.
- Add regression checks that the rendered editor HTML still includes the helper definitions.

Validation:
- `uv run --extra dev pytest -q tests/integration/test_app_question_save.py`
- `uv run --extra dev pytest -q tests/integration/test_browser_question_roundtrip.py`
- `uv run --extra dev black --check tests/integration/test_app_question_save.py`

Remaining risk:
- Browser-specific coverage is skipped if Playwright/Chromium is unavailable in the local environment.