### PR TITLE
Fix figure validation upload requests

### DIFF
--- a/src/exam_helper/app.py
+++ b/src/exam_helper/app.py
@@ -928,10 +928,25 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
         return {"sha256": sha256(raw).hexdigest(), "size": len(raw)}
 
     @app.post("/figures/summarize", response_model=None)
-    def summarize_figure(
-        data_base64: str = Form(...), mime_type: str = Form("image/png")
-    ) -> Any:
+    async def summarize_figure(request: Request) -> Any:
         try:
+            data_base64 = ""
+            mime_type = "image/png"
+            content_type = request.headers.get("content-type", "")
+            if content_type.startswith("application/json"):
+                payload = await request.json()
+                if isinstance(payload, dict):
+                    data_base64 = str(payload.get("data_base64", ""))
+                    mime_type = str(payload.get("mime_type", "image/png"))
+            else:
+                form = await request.form()
+                data_base64 = str(form.get("data_base64", ""))
+                mime_type = str(form.get("mime_type", "image/png"))
+            if not data_base64:
+                return JSONResponse(
+                    {"ok": False, "error": "Missing data_base64 payload."},
+                    status_code=400,
+                )
             normalized_mime, normalized_data = AIService._prepare_figure_summary_input(
                 mime_type, data_base64
             )

--- a/src/exam_helper/app.py
+++ b/src/exam_helper/app.py
@@ -910,7 +910,20 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
         return Response(content=raw, media_type=media_type)
 
     @app.post("/figures/validate")
-    def validate_figure(data_base64: str = Form(...)) -> dict:
+    async def validate_figure(request: Request) -> dict:
+        data_base64 = ""
+        content_type = request.headers.get("content-type", "")
+        if content_type.startswith("application/json"):
+            payload = await request.json()
+            if isinstance(payload, dict):
+                data_base64 = str(payload.get("data_base64", ""))
+        else:
+            form = await request.form()
+            data_base64 = str(form.get("data_base64", ""))
+        if not data_base64:
+            return JSONResponse(
+                {"ok": False, "error": "Missing data_base64 payload."}, status_code=400
+            )
         raw = base64.b64decode(data_base64.encode("ascii"))
         return {"sha256": sha256(raw).hexdigest(), "size": len(raw)}
 

--- a/src/exam_helper/templates/question_form_v2.html
+++ b/src/exam_helper/templates/question_form_v2.html
@@ -963,10 +963,11 @@
       }
 
       async function summarizeFigureData(mimeType, dataBase64) {
-        const body = new FormData();
-        body.append("mime_type", mimeType);
-        body.append("data_base64", dataBase64);
-        const res = await fetch("/figures/summarize", { method: "POST", body });
+        const res = await fetch("/figures/summarize", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ mime_type: mimeType, data_base64: dataBase64 }),
+        });
         const data = await res.json();
         if (!res.ok) {
           throw new Error(data.error || res.statusText || "Figure summary failed.");

--- a/src/exam_helper/templates/question_form_v2.html
+++ b/src/exam_helper/templates/question_form_v2.html
@@ -1051,9 +1051,11 @@
       }
 
       async function validateFigureData(dataBase64) {
-        const body = new FormData();
-        body.append("data_base64", dataBase64);
-        const res = await fetch("/figures/validate", { method: "POST", body });
+        const res = await fetch("/figures/validate", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ data_base64: dataBase64 }),
+        });
         const data = await res.json();
         if (!res.ok) throw new Error(data.error || res.statusText || "Figure validation failed.");
         return data;

--- a/tests/integration/test_app_question_save.py
+++ b/tests/integration/test_app_question_save.py
@@ -89,6 +89,35 @@ def test_summarize_figure_endpoint_returns_summary(tmp_path) -> None:
 
     resp = client.post(
         "/figures/summarize",
+        json={"data_base64": b64, "mime_type": "image/png"},
+    )
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["summary"] == "A block on an incline plane."
+
+
+def test_summarize_figure_endpoint_accepts_form_payload(tmp_path) -> None:
+    repo = ProjectRepository(tmp_path)
+    repo.init_project("Exam", "Physics")
+    app = create_app(tmp_path, openai_key="k")
+
+    class FakeAI:
+        def summarize_figure(self, *, mime_type: str, data_base64: str):
+            assert mime_type == "image/png"
+            assert data_base64 == b64
+            return AIService.AIResult(
+                text="A block on an incline plane.",
+                usage=AIUsageTotals(),
+            )
+
+    app.state.ai = FakeAI()
+    client = TestClient(app)
+
+    raw = b"png-bytes"
+    b64 = base64.b64encode(raw).decode("ascii")
+
+    resp = client.post(
+        "/figures/summarize",
         data={"data_base64": b64, "mime_type": "image/png"},
     )
     assert resp.status_code == 200

--- a/tests/integration/test_app_question_save.py
+++ b/tests/integration/test_app_question_save.py
@@ -60,7 +60,7 @@ def test_validate_figure_endpoint_returns_hash_and_size(tmp_path) -> None:
     b64 = base64.b64encode(raw).decode("ascii")
     digest = hashlib.sha256(raw).hexdigest()
 
-    resp = client.post("/figures/validate", data={"data_base64": b64})
+    resp = client.post("/figures/validate", json={"data_base64": b64})
     assert resp.status_code == 200
     payload = resp.json()
     assert payload["sha256"] == digest


### PR DESCRIPTION
## What changed
- Switched figure validation uploads from multipart form data to JSON in the editor UI.
- Updated `/figures/validate` and `/figures/summarize` to accept JSON while preserving form fallback for compatibility.
- Added integration coverage for the JSON request path and for summarize compatibility.

## Validation
- `uv run --extra dev pytest -q tests/integration/test_app_question_save.py`
- `uv run --extra dev pytest -q`
- `uv run --extra dev black --check .`

## Risk
- Low. The change is limited to figure upload and summary request handling and preserves legacy form support.

Fixes #125
Fixes #128