### PR TITLE
Collapse the empty chat log

### DIFF
--- a/src/exam_helper/templates/question_form_v2.html
+++ b/src/exam_helper/templates/question_form_v2.html
@@ -366,6 +366,9 @@
         background: #fff;
         padding: 0.85rem;
       }
+      .chat-log:empty {
+        display: none;
+      }
       .chat-history-window {
         display: flex;
         align-items: center;

--- a/tests/integration/test_app_ai_config_and_usage.py
+++ b/tests/integration/test_app_ai_config_and_usage.py
@@ -80,6 +80,7 @@ def test_question_editor_has_chat_workflow_hooks(tmp_path) -> None:
     assert 'title="Shift+Enter to send"' in resp.text
     assert 'title="No API key configured."' in resp.text
     assert "setChatBusy(true)" in resp.text
+    assert ".chat-log:empty" in resp.text
     assert 'event.key === "Enter" && event.shiftKey' in resp.text
 
 


### PR DESCRIPTION
Fixes #123

- Hide the empty chat log so the chat section no longer shows a blank bordered bar before any messages exist.
- Keep the populated chat history rendering unchanged.
- Added a regression assertion for the new empty-state CSS hook.

Validation:
- `uv run --extra dev pytest -q tests/integration/test_app_ai_config_and_usage.py -k chat_workflow_hooks`
- `uv run --extra dev black --check tests/integration/test_app_ai_config_and_usage.py`

Risk:
- This only changes the empty-state rendering; once messages are present, the chat log still renders normally.