### PR TITLE
Add SymPy `pi` guidance to prompts

### DIFF
--- a/src/exam_helper/prompt_templates.yaml
+++ b/src/exam_helper/prompt_templates.yaml
@@ -31,6 +31,7 @@ actions:
       If the final line assigns a new variable, set answer to that same value.
       If you create an answer variable, do not overwrite it.
       Do not wrap the expressions in a solve() function.
+      Use SymPy's pi symbol instead of decimal approximations when the exact value matters.
       Use ** for powers in SymPy; write x**2, not x^2.
       If LaTeX-style backslashes are needed inside Python string literals, escape them (for example \\theta, \\(x\\)).
       Do not include any prose before or after the JSON object.

--- a/tests/unit/test_prompt_catalog.py
+++ b/tests/unit/test_prompt_catalog.py
@@ -29,6 +29,7 @@ def test_prompt_catalog_builds_answer_formula_prompt() -> None:
     bundle = catalog.compose(action="generate_answer_formula", question=q)
     assert "Answer Formula (SymPy):" in bundle.user_prompt
     assert "Answer Text (Markdown):" in bundle.user_prompt
+    assert "SymPy's pi symbol" in bundle.system_prompt
     assert "Use ** for powers in SymPy" in bundle.system_prompt
 
 


### PR DESCRIPTION
Fixes #131

- Added prompt guidance to use SymPy's `pi` symbol instead of decimal approximations when exact values matter.
- Locked the guidance in with a prompt catalog test.

Validation:
- `uv run --extra dev pytest -q tests/unit/test_prompt_catalog.py`
- `uv run --extra dev black --check tests/unit/test_prompt_catalog.py`

Risk:
- Low. This only changes prompt wording and the associated prompt test.