### PR TITLE
Centralize AI prompt text in one catalog

### DIFF
--- a/src/exam_helper/ai_service.py
+++ b/src/exam_helper/ai_service.py
@@ -290,26 +290,21 @@ class AIService:
             mime_type, data_base64
         )
         client = self._client()
-        system_prompt = (
-            "You write concise figure summaries for a physics exam author. "
-            "Return plain text only, with one short sentence."
-        )
-        user_prompt = (
-            "Summarize the attached figure for the question author in one short "
-            "sentence. Mention the important objects, labels, and relationships. "
-            "Return plain text only."
+        bundle = self._catalog().render_prompt(
+            action="summarize_figure",
+            values={},
         )
         response = client.responses.create(
             model=self.model,
             input=[
                 {
                     "role": "system",
-                    "content": [{"type": "input_text", "text": system_prompt}],
+                    "content": [{"type": "input_text", "text": bundle.system_prompt}],
                 },
                 {
                     "role": "user",
                     "content": [
-                        {"type": "input_text", "text": user_prompt},
+                        {"type": "input_text", "text": bundle.user_prompt},
                         {
                             "type": "input_image",
                             "image_url": f"data:{normalized_mime};base64,{normalized_base64}",
@@ -755,28 +750,16 @@ class AIService:
         attached_ids = [
             str(fid).strip() for fid in (attached_figure_ids or []) if str(fid).strip()
         ]
-        system_prompt = (
-            "You are editing a single exam item for a physics-authoring app. "
-            "Use the provided tools to inspect and update the item. "
-            "Do not invent fields or return raw patches. "
-            "Use deterministic tools for answer and distractor changes. "
-            "For rewrite or parameter-extraction requests, call only the minimal tools needed. "
-            "Do not call compute_answer unless the author explicitly asks you to calculate, compute, or solve. "
-            "When you are done, call the finish tool exactly once with a short factual assistant_message."
+        bundle = self._catalog().render_prompt(
+            action="chat_edit_question",
+            values={
+                "editor_state_json": state_json,
+                "recent_chat_history": history_text,
+                "author_request": user_message.strip(),
+            },
         )
         user_content: list[dict[str, Any]] = [
-            {
-                "type": "input_text",
-                "text": (
-                    "Current editor state:\n"
-                    f"{state_json}\n\n"
-                    "Persisted recent chat history:\n"
-                    f"{history_text}\n\n"
-                    f"Current author request:\n{user_message.strip()}\n\n"
-                    "Figure metadata and summaries are included below. "
-                    "Only image bytes explicitly attached to this turn are included below."
-                ),
-            }
+            {"type": "input_text", "text": bundle.user_prompt}
         ]
         figure_prompt_text = self._figure_prompt_text(working)
         if figure_prompt_text:
@@ -795,7 +778,7 @@ class AIService:
             input=[
                 {
                     "role": "system",
-                    "content": [{"type": "input_text", "text": system_prompt}],
+                    "content": [{"type": "input_text", "text": bundle.system_prompt}],
                 },
                 {"role": "user", "content": user_content},
             ],

--- a/src/exam_helper/prompt_catalog.py
+++ b/src/exam_helper/prompt_catalog.py
@@ -51,11 +51,11 @@ class PromptCatalog:
                 raise ValueError(f"Action '{action_name}' missing user_prompt_template")
         return cls(actions=actions)
 
-    def compose(
+    def render_prompt(
         self,
         *,
         action: str,
-        question: Question,
+        values: dict[str, str],
         prompts_override: AIPromptConfig | None = None,
     ) -> PromptBundle:
         payload = self._actions.get(action)
@@ -71,6 +71,16 @@ class PromptCatalog:
             if action_override:
                 system_parts.append(action_override)
         system_prompt = "\n\n".join(p for p in system_parts if p)
+        user_prompt = self._safe_format(payload["user_prompt_template"], values)
+        return PromptBundle(system_prompt=system_prompt, user_prompt=user_prompt)
+
+    def compose(
+        self,
+        *,
+        action: str,
+        question: Question,
+        prompts_override: AIPromptConfig | None = None,
+    ) -> PromptBundle:
         rendered_question_md = render_template_from_values(
             question.solution.question_template_md or "",
             question.solution.parameters or {},
@@ -100,9 +110,11 @@ class PromptCatalog:
         values["context_sections"] = self._build_context_sections(
             action=action, values=values
         )
-        user_template = payload["user_prompt_template"]
-        user_prompt = self._safe_format(user_template, values)
-        return PromptBundle(system_prompt=system_prompt, user_prompt=user_prompt)
+        return self.render_prompt(
+            action=action,
+            values=values,
+            prompts_override=prompts_override,
+        )
 
     @staticmethod
     def figure_placeholders(question: Question) -> list[str]:

--- a/src/exam_helper/prompt_templates.yaml
+++ b/src/exam_helper/prompt_templates.yaml
@@ -1,4 +1,6 @@
 actions:
+  # Used by AIService.rewrite_parameterize() when the editor asks the LLM to turn a rough
+  # question draft into a reusable template plus numeric parameters.
   rewrite_parameterize:
     system_prompt: |
       Return exactly one strict JSON object with keys:
@@ -19,6 +21,8 @@ actions:
       Rewrite this question and extract parameters.
 
       {context_sections}
+  # Used by AIService.generate_answer_formula() when the editor needs a deterministic
+  # SymPy answer formula for the current question state.
   generate_answer_formula:
     system_prompt: |
       Return exactly one strict JSON object with one key:
@@ -38,6 +42,8 @@ actions:
       Write or revise the deterministic Answer Formula (SymPy expressions).
 
       {context_sections}
+  # Used by AIService.generate_distractor_functions() when generating four deterministic
+  # distractor functions for a multiple-choice question.
   generate_distractor_functions:
     system_prompt: |
       Return exactly one strict JSON object with one key:
@@ -61,6 +67,8 @@ actions:
       Write deterministic distractor functions for multiple-choice options.
 
       {context_sections}
+  # Used by AIService.generate_typed_solution() when writing a short worked solution for
+  # the author-facing typed-solution panel.
   generate_typed_solution:
     system_prompt: |
       Return only Markdown for the worked solution.
@@ -73,3 +81,37 @@ actions:
       Write or revise the worked Typed Solution (Markdown).
 
       {context_sections}
+  # Used by AIService.summarize_figure() after a user uploads or pastes a figure in the
+  # figure editor or chat panel and the app needs a short caption for the image.
+  summarize_figure:
+    system_prompt: |
+      You write concise figure summaries for a physics exam author.
+      Return plain text only, with one short sentence.
+    user_prompt_template: |
+      Summarize the attached figure for the question author in one short sentence.
+      Mention the important objects, labels, and relationships.
+      Return plain text only.
+  # Used by AIService.chat_edit_question() when the question editor chat sends the current
+  # editor state, recent chat history, and the author request to the model.
+  chat_edit_question:
+    system_prompt: |
+      You are editing a single exam item for a physics-authoring app.
+      Use the provided tools to inspect and update the item.
+      Do not invent fields or return raw patches.
+      Use deterministic tools for answer and distractor changes.
+      For rewrite or parameter-extraction requests, call only the minimal tools needed.
+      Do not call compute_answer unless the author explicitly asks you to calculate, compute, or solve.
+      If the author is asking to build a new problem from a screenshot or pasted image, treat the image as the source of truth and fill every relevant field: question text, parameters, answer formula, distractors, and typed solution.
+      When you are done, call the finish tool exactly once with a short factual assistant_message.
+    user_prompt_template: |
+      Current editor state:
+      {editor_state_json}
+
+      Persisted recent chat history:
+      {recent_chat_history}
+
+      Current author request:
+      {author_request}
+
+      Figure metadata and summaries are included below.
+      Only image bytes explicitly attached to this turn are included below.

--- a/tests/unit/test_prompt_catalog.py
+++ b/tests/unit/test_prompt_catalog.py
@@ -60,6 +60,30 @@ def test_prompt_catalog_applies_solution_and_mc_override_to_answer_generation() 
     assert "Keep units explicit in final_answer." in bundle.system_prompt
 
 
+def test_prompt_catalog_builds_figure_summary_prompt() -> None:
+    catalog = PromptCatalog.from_package_yaml()
+    bundle = catalog.render_prompt(action="summarize_figure", values={})
+    assert "figure summaries" in bundle.system_prompt
+    assert "Summarize the attached figure" in bundle.user_prompt
+    assert "plain text only" in bundle.user_prompt
+
+
+def test_prompt_catalog_builds_chat_editor_prompt() -> None:
+    catalog = PromptCatalog.from_package_yaml()
+    bundle = catalog.render_prompt(
+        action="chat_edit_question",
+        values={
+            "editor_state_json": "{}",
+            "recent_chat_history": "(none)",
+            "author_request": "rewrite this",
+        },
+    )
+    assert "physics-authoring app" in bundle.system_prompt
+    assert "screenshot or pasted image" in bundle.system_prompt
+    assert "Current editor state:" in bundle.user_prompt
+    assert "rewrite this" in bundle.user_prompt
+
+
 def test_prompt_catalog_omits_empty_old_code_sections() -> None:
     catalog = PromptCatalog.from_package_yaml()
     q = Question(id="q1", title="T", prompt_md="P")


### PR DESCRIPTION
Fixes #130

- Moved the figure-summary and chat-editor prompts into `prompt_templates.yaml` alongside the existing AI prompt catalog entries.
- Added inline comments in the catalog so each prompt documents where it is used.
- Kept the prompt rendering logic in one place by adding a catalog helper for arbitrary prompt payloads.

Validation:
- `uv run --extra dev pytest -q tests/unit/test_prompt_catalog.py`
- `uv run --extra dev pytest -q`
- `uv run --extra dev black --check tests/unit/test_prompt_catalog.py src/exam_helper/prompt_catalog.py src/exam_helper/ai_service.py`

Risk:
- Low to moderate. This is a prompt-text refactor plus a small rendering helper, so the main risk is accidental prompt wording drift, which the tests cover.