### PR TITLE
Send pasted chat images only to the LLM by default

### DIFF
--- a/src/exam_helper/ai_service.py
+++ b/src/exam_helper/ai_service.py
@@ -241,6 +241,34 @@ class AIService:
             )
         return items
 
+    @classmethod
+    def _chat_image_content(
+        cls, chat_images: list[dict[str, Any]] | None = None
+    ) -> list[dict]:
+        items: list[dict] = []
+        for idx, image in enumerate(chat_images or [], start=1):
+            mime_type = str(image.get("mime_type", "") or "").strip()
+            data_base64 = str(image.get("data_base64", "") or "").strip()
+            if not data_base64:
+                continue
+            normalized_mime, normalized_base64 = cls._prepare_figure_summary_input(
+                mime_type, data_base64
+            )
+            items.append(
+                {
+                    "type": "input_text",
+                    "text": f"Chat image {idx}:",
+                }
+            )
+            items.append(
+                {
+                    "type": "input_image",
+                    "image_url": (f"data:{normalized_mime};base64,{normalized_base64}"),
+                    "detail": "low",
+                }
+            )
+        return items
+
     @staticmethod
     def _figure_summaries(question: Question) -> list[str]:
         summaries: list[str] = []
@@ -729,6 +757,7 @@ class AIService:
         question: Question,
         user_message: str,
         attached_figure_ids: list[str] | None = None,
+        chat_images: list[dict[str, Any]] | None = None,
         history_keep_count: int = 5,
     ) -> QuestionEditorResult:
         client = self._client()
@@ -773,6 +802,17 @@ class AIService:
                 }
             )
             user_content.extend(self._figure_content(working, attached_ids))
+        chat_image_items = self._chat_image_content(chat_images)
+        if chat_image_items:
+            user_content.append(
+                {
+                    "type": "input_text",
+                    "text": (
+                        "Chat-only pasted images for this turn are included below."
+                    ),
+                }
+            )
+            user_content.extend(chat_image_items)
         response = client.responses.create(
             model=self.model,
             input=[

--- a/src/exam_helper/app.py
+++ b/src/exam_helper/app.py
@@ -69,6 +69,7 @@ AutosavePayload = QuestionEditorState
 class ChatPayload(BaseModel):
     message: str = ""
     attached_figure_ids: list[str] = Field(default_factory=list)
+    chat_images: list[dict[str, str]] = Field(default_factory=list)
     editor_state: QuestionEditorState
     history_keep_count: int = Field(default=5, ge=0)
 
@@ -986,6 +987,7 @@ def create_app(project_root: Path, openai_key: str | None) -> FastAPI:
                 live_question,
                 payload.message,
                 attached_figure_ids=payload.attached_figure_ids,
+                chat_images=payload.chat_images,
                 history_keep_count=payload.history_keep_count,
             )
             question_for_log = result.question

--- a/src/exam_helper/templates/question_form_v2.html
+++ b/src/exam_helper/templates/question_form_v2.html
@@ -436,6 +436,22 @@
         background: #fff;
         font-size: 0.9rem;
       }
+      .chat-attachment--ephemeral {
+        background: #f8fafc;
+        border-color: #cbd5e1;
+        color: #0f172a;
+      }
+      .chat-attachment-mode {
+        display: flex;
+        align-items: center;
+        gap: 0.55rem;
+        color: var(--muted);
+        font-size: 0.94rem;
+      }
+      .chat-attachment-mode input {
+        width: auto;
+        margin: 0;
+      }
       @media (max-width: 900px) {
         .row, .row3, .mc-preview-grid {
           grid-template-columns: 1fr;
@@ -521,6 +537,14 @@
                 {% if not ai_enabled %}disabled{% endif %}
               ></textarea>
               <div id="chat_attachments" class="chat-attachments"></div>
+              <label class="chat-attachment-mode">
+                <input
+                  type="checkbox"
+                  id="chat_attach_images_to_problem"
+                  {% if not ai_enabled %}disabled{% endif %}
+                />
+                Attach pasted images to problem
+              </label>
               <div class="actions">
                 <button
                   type="button"
@@ -724,11 +748,13 @@
       const chatSendBtn = document.getElementById("btn_send_chat");
       const chatStatusEl = document.getElementById("chat_status");
       const chatAttachmentsEl = document.getElementById("chat_attachments");
+      const chatAttachImagesToProblemEl = document.getElementById("chat_attach_images_to_problem");
       const chatPanelEl = document.querySelector(".chat-panel");
       const chatEnabled = {{ 'true' if ai_enabled else 'false' }};
       let editorState = {{ editor_state | tojson }};
       let autosaveTimer = null;
       let pendingChatFigureIds = [];
+      let pendingChatImages = [];
       let figureModalLastFocus = null;
       let figureNoticeTimer = null;
 
@@ -1111,25 +1137,37 @@
 
       async function addChatAttachmentFromFile(file) {
         if (!file || !isSupportedFigureFile(file)) return false;
-        const figures = parseFigures();
-        const pendingId = nextFigureId(figures);
+        const attachToProblem = !!chatAttachImagesToProblemEl?.checked;
         setChatStatus("Processing chat image...", "warn");
         const figure = await buildFigureFromFile(file);
-        showFigureNotice("Generating figure summary...", { timeoutMs: null });
-        try {
-          figure.caption = await summarizeFigureData(figure.mime_type, figure.data_base64);
-          clearFigureNotice();
-        } catch (err) {
-          figure.caption = "";
-          showFigureNotice(`Figure added without AI summary: ${err.message}`);
+        if (attachToProblem) {
+          const figures = parseFigures();
+          const pendingId = nextFigureId(figures);
+          showFigureNotice("Generating figure summary...", { timeoutMs: null });
+          try {
+            figure.caption = await summarizeFigureData(figure.mime_type, figure.data_base64);
+            clearFigureNotice();
+          } catch (err) {
+            figure.caption = "";
+            showFigureNotice(`Figure added without AI summary: ${err.message}`);
+          }
+          figure.id = pendingId;
+          figures.push(figure);
+          setFigures(figures);
+          pendingChatFigureIds.push(pendingId);
+          renderPendingChatAttachments();
+          scheduleAutosave();
+          setChatStatus(`Attached ${pendingId}`, "good");
+        } else {
+          const pendingLabel = `chat_img_${pendingChatImages.length + 1}`;
+          pendingChatImages.push({
+            label: pendingLabel,
+            mime_type: figure.mime_type,
+            data_base64: figure.data_base64,
+          });
+          renderPendingChatAttachments();
+          setChatStatus(`Queued ${pendingLabel} for the LLM`, "good");
         }
-        figure.id = pendingId;
-        figures.push(figure);
-        setFigures(figures);
-        pendingChatFigureIds.push(pendingId);
-        renderPendingChatAttachments();
-        scheduleAutosave();
-        setChatStatus(`Attached ${pendingId}`, "good");
         return true;
       }
 
@@ -1380,31 +1418,60 @@
       }
 
       function renderPendingChatAttachments() {
-        if (!pendingChatFigureIds.length) {
+        if (!pendingChatFigureIds.length && !pendingChatImages.length) {
           chatAttachmentsEl.innerHTML = "";
           return;
         }
-        chatAttachmentsEl.innerHTML = pendingChatFigureIds.map((id) => (
+        const figureChips = pendingChatFigureIds.map((id) => (
           `<span class="chat-attachment">${escapeHtml(id)}</span>`
-        )).join("");
+        ));
+        const chatImageChips = pendingChatImages.map((item) => (
+          `<span class="chat-attachment chat-attachment--ephemeral">${
+            escapeHtml(item.label)
+          }</span>`
+        ));
+        chatAttachmentsEl.innerHTML = [...figureChips, ...chatImageChips].join("");
       }
 
-      function createChatMessageElement(role, text, attachedFigureIds = []) {
+      function createChatMessageElement(
+        role,
+        text,
+        attachedFigureIds = [],
+        attachedChatImages = [],
+      ) {
         const item = document.createElement("div");
         item.className = `chat-message ${role}`;
-        const attachments = Array.isArray(attachedFigureIds) && attachedFigureIds.length
-          ? `<div class="hint">Figures: ${attachedFigureIds.map((id) => escapeHtml(id)).join(", ")}</div>`
-          : "";
+        const attachments = [];
+        if (Array.isArray(attachedFigureIds) && attachedFigureIds.length) {
+          attachments.push(
+            `<div class="hint">Figures: ${attachedFigureIds.map((id) => escapeHtml(id)).join(", ")}</div>`
+          );
+        }
+        if (Array.isArray(attachedChatImages) && attachedChatImages.length) {
+          attachments.push(
+            `<div class="hint">Chat images: ${attachedChatImages.map((id) => escapeHtml(id)).join(", ")}</div>`
+          );
+        }
         item.innerHTML = `
           <div class="chat-role">${role === "assistant" ? "Assistant" : "You"}</div>
           <div>${escapeHtml(String(text || "")).replace(/\n/g, "<br>")}</div>
-          ${attachments}
+          ${attachments.join("")}
         `;
         return item;
       }
 
-      function renderChatMessage(role, text, attachedFigureIds = []) {
-        const item = createChatMessageElement(role, text, attachedFigureIds);
+      function renderChatMessage(
+        role,
+        text,
+        attachedFigureIds = [],
+        attachedChatImages = [],
+      ) {
+        const item = createChatMessageElement(
+          role,
+          text,
+          attachedFigureIds,
+          attachedChatImages,
+        );
         chatThreadEl.appendChild(item);
         chatThreadEl.scrollTop = chatThreadEl.scrollHeight;
       }
@@ -1463,8 +1530,9 @@
         if (autosaveTimer) clearTimeout(autosaveTimer);
         setChatBusy(true);
         const attachedFigureIds = pendingChatFigureIds.slice();
+        const attachedChatImages = pendingChatImages.map((item) => item.label);
         setChatStatus("Thinking...", "warn");
-        renderChatMessage("user", message, attachedFigureIds);
+        renderChatMessage("user", message, attachedFigureIds, attachedChatImages);
         chatMessageEl.value = "";
         try {
           const res = await fetch(`/questions/${qid}/ai/chat`, {
@@ -1473,6 +1541,10 @@
             body: JSON.stringify({
               message,
               attached_figure_ids: attachedFigureIds,
+              chat_images: pendingChatImages.map((item) => ({
+                mime_type: item.mime_type,
+                data_base64: item.data_base64,
+              })),
               history_keep_count: chatHistoryKeepCount(),
               editor_state: serializePayload(),
             }),
@@ -1484,6 +1556,7 @@
           renderChatMessage("assistant", data.assistant_message || "(no response)");
           applyAssistantResponse(data);
           pendingChatFigureIds = [];
+          pendingChatImages = [];
           renderPendingChatAttachments();
         } catch (err) {
           setChatStatus(`Chat error: ${err.message}`, "warn");

--- a/tests/integration/test_autosave_and_ai_errors.py
+++ b/tests/integration/test_autosave_and_ai_errors.py
@@ -655,6 +655,7 @@ def test_ai_chat_updates_question_and_returns_payload(tmp_path) -> None:
             question,
             user_message,
             attached_figure_ids=None,
+            chat_images=None,
             history_keep_count=None,
         ):
             assert question.id == "q_chat"
@@ -715,6 +716,7 @@ def test_ai_chat_refreshes_rendered_answer_when_guidance_changes(tmp_path) -> No
             question,
             user_message,
             attached_figure_ids=None,
+            chat_images=None,
             history_keep_count=None,
         ):
             updated = question.model_copy(deep=True)
@@ -764,6 +766,7 @@ def test_ai_chat_uses_live_editor_state_and_persists_full_history(tmp_path) -> N
             question,
             user_message,
             attached_figure_ids=None,
+            chat_images=None,
             history_keep_count=None,
         ):
             assert question.title == "Unsaved local title"
@@ -821,6 +824,63 @@ def test_ai_chat_uses_live_editor_state_and_persists_full_history(tmp_path) -> N
     assert saved.solution.chat_history[0].user_message == "user 1"
 
 
+def test_ai_chat_forwards_chat_images_without_persisting_figures(tmp_path) -> None:
+    repo = ProjectRepository(tmp_path)
+    repo.init_project("Exam", "Physics")
+    app = create_app(tmp_path, openai_key="k")
+    client = TestClient(app)
+    _seed_question(client, "q_chat_images")
+
+    captured: dict[str, object] = {}
+
+    class _AI:
+        def chat_edit_question(
+            self,
+            question,
+            user_message,
+            attached_figure_ids=None,
+            chat_images=None,
+            history_keep_count=None,
+        ):
+            captured["question_figures"] = [fig.id for fig in question.figures]
+            captured["attached_figure_ids"] = attached_figure_ids
+            captured["chat_images"] = chat_images
+            updated = question.model_copy(deep=True)
+            updated.solution.last_computed_answer_md = "ok"
+            return AIService.QuestionEditorResult(
+                assistant_message="Stored the answer.",
+                question=updated,
+                warnings=[],
+                usage=AIUsageTotals(),
+                changed_fields=[],
+            )
+
+    app.state.ai = _AI()
+    original = repo.get_question("q_chat_images")
+    chat_image_b64 = (
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8"
+        "/w8AAgMBgU7Y5e0AAAAASUVORK5CYII="
+    )
+    resp = client.post(
+        "/questions/q_chat_images/ai/chat",
+        json={
+            "message": "Please rewrite this problem.",
+            "attached_figure_ids": [],
+            "chat_images": [
+                {"mime_type": "image/png", "data_base64": chat_image_b64},
+            ],
+            "editor_state": _editor_state_for_question(original),
+        },
+    )
+    assert resp.status_code == 200
+    assert captured["attached_figure_ids"] == []
+    assert len(captured["chat_images"]) == 1
+    assert captured["question_figures"] == []
+    saved = repo.get_question("q_chat_images")
+    assert saved.figures == []
+    assert saved.solution.chat_history[-1].attached_figure_ids == []
+
+
 def test_ai_chat_forwards_requested_history_window(tmp_path) -> None:
     repo = ProjectRepository(tmp_path)
     repo.init_project("Exam", "Physics")
@@ -834,6 +894,7 @@ def test_ai_chat_forwards_requested_history_window(tmp_path) -> None:
             question,
             user_message,
             attached_figure_ids=None,
+            chat_images=None,
             history_keep_count=None,
         ):
             assert history_keep_count == 2
@@ -874,6 +935,7 @@ def test_autosave_after_chat_keeps_chat_applied_solution_fields(tmp_path) -> Non
             question,
             user_message,
             attached_figure_ids=None,
+            chat_images=None,
             history_keep_count=None,
         ):
             updated = question.model_copy(deep=True)

--- a/tests/integration/test_browser_question_roundtrip.py
+++ b/tests/integration/test_browser_question_roundtrip.py
@@ -184,6 +184,172 @@ def test_browser_question_roundtrip(tmp_path: Path) -> None:
             proc.wait(timeout=10)
 
 
+def test_browser_chat_image_paste_defaults_to_llm_only_and_can_attach(
+    tmp_path: Path,
+) -> None:
+    pytest.importorskip("playwright.sync_api")
+    from playwright.sync_api import Error as PlaywrightError, sync_playwright
+
+    repo = ProjectRepository(tmp_path)
+    repo.init_project("Chat Images Exam", "Physics 1")
+    port = _free_port()
+    base_url = f"http://127.0.0.1:{port}"
+
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "exam_helper.cli",
+            "serve",
+            str(tmp_path),
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    try:
+        _wait_for_server(base_url + "/", proc)
+        seed = httpx.post(
+            base_url + "/questions/save",
+            data={
+                "question_id": "q_chat_images",
+                "title": "Chat Images Test",
+                "question_type": "free_response",
+                "question_template_md": "Prompt.",
+                "solution_parameters_yaml": "{}",
+                "answer_formula_md": "answer = 1",
+                "answer_guidance": "",
+                "mc_options_guidance": "",
+                "distractor_functions_text": "",
+                "choices_yaml": "[]",
+                "typed_solution_md": "",
+                "typed_solution_status": "fresh",
+                "figures_json": "[]",
+                "points": 5,
+            },
+            follow_redirects=False,
+            timeout=5.0,
+        )
+        assert seed.status_code == 303
+        with sync_playwright() as p:
+            try:
+                browser = p.chromium.launch(headless=True)
+            except PlaywrightError as exc:
+                pytest.skip(f"Chromium is not available: {exc}")
+            try:
+                page = browser.new_page()
+                page.goto(base_url + "/questions/q_chat_images/edit")
+                page.wait_for_url(base_url + "/questions/q_chat_images/edit")
+
+                page.evaluate("""() => {
+                        window.__chatBodies = [];
+                        const originalFetch = window.fetch.bind(window);
+                        window.fetch = async (input, init) => {
+                          const url = typeof input === "string" ? input : String(input.url || "");
+                          if (url.includes("/figures/validate")) {
+                            return new Response(JSON.stringify({
+                              sha256: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+                              size: 4
+                            }), {
+                              status: 200,
+                              headers: { "Content-Type": "application/json" }
+                            });
+                          }
+                          if (url.includes("/figures/summarize")) {
+                            return new Response(JSON.stringify({ summary: "chat attachment" }), {
+                              status: 200,
+                              headers: { "Content-Type": "application/json" }
+                            });
+                          }
+                          if (url.includes("/questions/q_chat_images/ai/chat")) {
+                            window.__chatBodies.push(JSON.parse(String(init?.body || "{}")));
+                            return new Response(JSON.stringify({
+                              ok: true,
+                              assistant_message: "Done"
+                            }), {
+                              status: 200,
+                              headers: { "Content-Type": "application/json" }
+                            });
+                          }
+                          return originalFetch(input, init);
+                        };
+                      }""")
+
+                page.locator("#chat_message").evaluate("""(textarea) => {
+                        const transfer = new DataTransfer();
+                        transfer.items.add(new File(
+                          [new Uint8Array([1, 2, 3, 4])],
+                          "chat.png",
+                          { type: "image/png" }
+                        ));
+                        const event = new Event("paste", { bubbles: true, cancelable: true });
+                        Object.defineProperty(event, "clipboardData", {
+                          value: transfer
+                        });
+                        textarea.dispatchEvent(event);
+                    }""")
+
+                page.wait_for_function(
+                    "() => document.querySelector('#chat_attachments')?.innerText.includes('chat_img_1')"
+                )
+                assert (
+                    "No embedded figures yet."
+                    in page.locator("#figures_preview").inner_text()
+                )
+
+                page.locator("#chat_message").fill("Please rewrite this problem.")
+                page.locator("#btn_send_chat").click()
+                page.wait_for_function("() => window.__chatBodies?.length === 1")
+                first_body = page.evaluate("() => window.__chatBodies[0]")
+                assert first_body["attached_figure_ids"] == []
+                assert len(first_body["chat_images"]) == 1
+                assert "mime_type" in first_body["chat_images"][0]
+                assert "data_base64" in first_body["chat_images"][0]
+                assert (
+                    page.locator("#figures_preview").inner_text().strip()
+                    == "No embedded figures yet."
+                )
+
+                page.locator("#chat_attach_images_to_problem").check()
+                page.locator("#chat_message").evaluate("""(textarea) => {
+                        const transfer = new DataTransfer();
+                        transfer.items.add(new File(
+                          [new Uint8Array([5, 6, 7, 8])],
+                          "problem.png",
+                          { type: "image/png" }
+                        ));
+                        const event = new Event("paste", { bubbles: true, cancelable: true });
+                        Object.defineProperty(event, "clipboardData", {
+                          value: transfer
+                        });
+                        textarea.dispatchEvent(event);
+                    }""")
+                page.wait_for_function(
+                    "() => document.querySelectorAll('#figures_preview .figure-item').length === 1"
+                )
+
+                page.locator("#chat_message").fill("Attach this one to the problem.")
+                page.locator("#btn_send_chat").click()
+                page.wait_for_function("() => window.__chatBodies?.length === 2")
+                second_body = page.evaluate("() => window.__chatBodies[1]")
+                assert len(second_body["attached_figure_ids"]) == 1
+                assert second_body["chat_images"] == []
+                assert page.locator("#figures_preview .figure-item").count() == 1
+            finally:
+                browser.close()
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=10)
+
+
 def test_browser_chat_response_updates_visible_mc_rows(tmp_path: Path) -> None:
     pytest.importorskip("playwright.sync_api")
     from playwright.sync_api import Error as PlaywrightError, sync_playwright


### PR DESCRIPTION
Fixes #121

- Added a chat-image payload separate from persistent problem figures.
- Default pasted images now go to the LLM only, while a checkbox still allows attaching them to the problem when desired.
- Added backend and browser regressions for the default chat-only path and the opt-in attach path.

Validation:
- `uv run --extra dev pytest -q tests/integration/test_autosave_and_ai_errors.py -k chat_images`
- `uv run --extra dev pytest -q tests/integration/test_browser_question_roundtrip.py -k chat_image_paste_defaults_to_llm_only_and_can_attach`
- `uv run --extra dev pytest -q`
- `uv run --extra dev black --check src/exam_helper/app.py src/exam_helper/ai_service.py tests/integration/test_autosave_and_ai_errors.py tests/integration/test_browser_question_roundtrip.py`

Risk:
- Moderate. This changes the chat payload shape and the image-attachment UX, but the new behavior is covered by both server and browser tests.