### PR TITLE
Clarify chat prompt for image-driven problem drafting

### DIFF
--- a/src/exam_helper/ai_service.py
+++ b/src/exam_helper/ai_service.py
@@ -762,6 +762,9 @@ class AIService:
             "Use deterministic tools for answer and distractor changes. "
             "For rewrite or parameter-extraction requests, call only the minimal tools needed. "
             "Do not call compute_answer unless the author explicitly asks you to calculate, compute, or solve. "
+            "If the author is starting from a screenshot, pasted image, or other new-problem source, "
+            "treat that source as the ground truth and fill every relevant field: question text, "
+            "parameters, answer formula, distractors, and typed solution. "
             "When you are done, call the finish tool exactly once with a short factual assistant_message."
         )
         user_content: list[dict[str, Any]] = [

--- a/tests/unit/test_ai_service.py
+++ b/tests/unit/test_ai_service.py
@@ -391,6 +391,11 @@ def test_ai_service_chat_edit_question_includes_figure_metadata_in_prompt(
     out = svc.chat_edit_question(q, "rewrite this")
 
     assert out.assistant_message == "Updated."
+    system_prompt = recording_client.responses.calls[0]["input"][0]["content"][0][
+        "text"
+    ]
+    assert "screenshot, pasted image, or other new-problem source" in system_prompt
+    assert "fill every relevant field" in system_prompt
     prompt_text = "\n".join(
         item["text"]
         for item in recording_client.responses.calls[0]["input"][1]["content"]


### PR DESCRIPTION
Fixes #127

- Added explicit chat prompt guidance for image-driven problem drafting: when the author starts from a screenshot or pasted image, the model should treat that source as the ground truth and fill every relevant field.
- Locked the new prompt wording into an AI service unit test so the screenshot/new-problem instruction stays in place.

Validation:
- `uv run --extra dev pytest -q tests/unit/test_ai_service.py -k chat_edit_question`
- `uv run --extra dev pytest -q`
- `uv run --extra dev black --check src/exam_helper/ai_service.py tests/unit/test_ai_service.py`

Risk:
- Low. This changes only the chat system prompt wording and the associated unit coverage.