### PR TITLE
Fix SymPy names in answer formulas

### DIFF
--- a/src/exam_helper/prompt_templates.yaml
+++ b/src/exam_helper/prompt_templates.yaml
@@ -36,6 +36,8 @@ actions:
       If you create an answer variable, do not overwrite it.
       Do not wrap the expressions in a solve() function.
       Use ** for powers in SymPy; write x**2, not x^2.
+      Use common SymPy constants and functions directly, such as pi, E, sin(x), cos(x), sqrt(x), exp(x), and log(x).
+      Do not invent non-SymPy forms like PI, pi(), or SIN().
       If LaTeX-style backslashes are needed inside Python string literals, escape them (for example \\theta, \\(x\\)).
       Do not include any prose before or after the JSON object.
     user_prompt_template: |

--- a/src/exam_helper/solution_runtime.py
+++ b/src/exam_helper/solution_runtime.py
@@ -15,6 +15,32 @@ from exam_helper.normalization import normalize_python_code_string_literals
 
 ureg = UnitRegistry()
 
+_SYMPY_NAMES: dict[str, Any] = {
+    "E": sp.E,
+    "I": sp.I,
+    "Abs": sp.Abs,
+    "acos": sp.acos,
+    "acosh": sp.acosh,
+    "asin": sp.asin,
+    "asinh": sp.asinh,
+    "atan": sp.atan,
+    "atanh": sp.atanh,
+    "ceiling": sp.ceiling,
+    "cos": sp.cos,
+    "cosh": sp.cosh,
+    "exp": sp.exp,
+    "floor": sp.floor,
+    "log": sp.log,
+    "oo": sp.oo,
+    "pi": sp.pi,
+    "sec": sp.sec,
+    "sin": sp.sin,
+    "sinh": sp.sinh,
+    "sqrt": sp.sqrt,
+    "tan": sp.tan,
+    "tanh": sp.tanh,
+}
+
 
 class SolutionRuntimeError(RuntimeError):
     pass
@@ -96,6 +122,7 @@ def _safe_globals() -> dict[str, Any]:
         "math": math,
         "sp": sp,
         "ureg": ureg,
+        **_SYMPY_NAMES,
         "symbolic_equivalent": symbolic_equivalent,
         "units_compatible": units_compatible,
     }

--- a/tests/unit/test_prompt_catalog.py
+++ b/tests/unit/test_prompt_catalog.py
@@ -30,6 +30,8 @@ def test_prompt_catalog_builds_answer_formula_prompt() -> None:
     assert "Answer Formula (SymPy):" in bundle.user_prompt
     assert "Answer Text (Markdown):" in bundle.user_prompt
     assert "Use ** for powers in SymPy" in bundle.system_prompt
+    assert "common SymPy constants and functions directly" in bundle.system_prompt
+    assert "pi, E, sin(x), cos(x), sqrt(x), exp(x), and log(x)" in bundle.system_prompt
 
 
 def test_prompt_catalog_applies_overall_and_rewrite_override() -> None:

--- a/tests/unit/test_solution_runtime.py
+++ b/tests/unit/test_solution_runtime.py
@@ -82,6 +82,12 @@ def test_answer_formula_tracks_last_expression() -> None:
     assert result.final_answer == "3"
 
 
+def test_answer_formula_supports_sympy_constants_and_functions() -> None:
+    result = run_answer_formula("answer = sin(pi / 2)", {}, strict=True)
+    assert result.calculated_variables_md == "answer = 1"
+    assert result.final_answer == "1"
+
+
 def test_answer_formula_formats_numeric_values_with_sig_figs() -> None:
     result = run_answer_formula(
         "x = 0.1\nanswer = 238.28347281",


### PR DESCRIPTION
Fixes #137

- Add common SymPy constants and functions to the answer-formula runtime namespace so formulas can use names like `pi` and `sin` directly.
- Update the answer-formula generation prompt to tell AI drafts to use standard SymPy names.
- Add tests covering `sin(pi / 2)` and the prompt guidance.

Validation:
- `uv run --extra dev pytest -q tests/unit/test_solution_runtime.py tests/unit/test_prompt_catalog.py`
- `uv run --extra dev black --check .`
- `uv run --extra dev pytest -q`

Remaining risk:
- The allowed SymPy name set is intentionally curated rather than exhaustive; if we need more builtins later, they can be added without changing the evaluation model.